### PR TITLE
fix: allow changing short existing passwords

### DIFF
--- a/app/utils/forms/ChangePasswordForm.py
+++ b/app/utils/forms/ChangePasswordForm.py
@@ -17,7 +17,6 @@ class ChangePasswordForm(Form):
     oldPassword = PasswordField(
         "oldPassword",
         [
-            validators.Length(min=8),
             validators.InputRequired(),
         ],
     )


### PR DESCRIPTION
## Summary
- remove length requirement on the old password field to allow updating short default passwords

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae5eb915bc8327886bfe036e9892e6