### PR TITLE
Add infinite scroll and view-based ranking for posts

### DIFF
--- a/app/routes/changePassword.py
+++ b/app/routes/changePassword.py
@@ -29,6 +29,8 @@ def changePassword():
         render_template: a rendered template with the form
     """
 
+    language = session.get("language", "en")
+
     if "userName" in session:
         form = ChangePasswordForm(request.form)
 
@@ -53,7 +55,7 @@ def changePassword():
                         page="changePassword",
                         message="same",
                         category="error",
-                        language=session["language"],
+                        language=language,
                     )
 
                 if password != passwordConfirm:
@@ -61,7 +63,7 @@ def changePassword():
                         page="changePassword",
                         message="match",
                         category="error",
-                        language=session["language"],
+                        language=language,
                     )
 
                 if oldPassword != password and password == passwordConfirm:
@@ -83,11 +85,12 @@ def changePassword():
                     )
 
                     session.clear()
+                    session["language"] = language
                     flashMessage(
                         page="changePassword",
                         message="success",
                         category="success",
-                        language=session["language"],
+                        language=language,
                     )
 
                     return redirect("/login/redirect=&")
@@ -96,7 +99,7 @@ def changePassword():
                     page="changePassword",
                     message="old",
                     category="error",
-                    language=session["language"],
+                    language=language,
                 )
 
         return render_template(
@@ -111,7 +114,7 @@ def changePassword():
             page="changePassword",
             message="login",
             category="error",
-            language=session["language"],
+            language=language,
         )
 
         return redirect("/login/redirect=changepassword")

--- a/app/templates/components/postCards.html
+++ b/app/templates/components/postCards.html
@@ -1,0 +1,4 @@
+{% for post in posts %}
+    {% from "components/postCardMacro.html" import postCard with context %}
+    {{ postCard(post=post, authorProfilePicture=getProfilePicture(post[5])) }}
+{% endfor %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -35,6 +35,7 @@
 </div>
 
 <div
+    id="posts-container"
     class="flex item-center justify-center flex-wrap gap-x-4 gap-y-6 mx-auto w-11/12 md:w-11/12 lg:w-10/12 2xl:w-9/12 mt-6"
 >
     {% for post in posts %}
@@ -42,9 +43,6 @@
         {{ postCard(post=post, authorProfilePicture=getProfilePicture(post[5])) }}
     {% endfor %}
 </div>
-
-{% from "components/pagination.html" import pagination %}
-{{ pagination(page, total_pages, request.path) }}
 
 <div class="text-center mt-4 mb-2 text-xs font-medium">
     <div class="mb-1">
@@ -58,4 +56,49 @@
     {{ translations.about.credits | safe }}
     <br />
 </div>
+
+<script>
+    const postsContainer = document.getElementById('posts-container');
+    let page = 1;
+    const totalPages = {{ total_pages }};
+    const by = "{{ by }}";
+    const sort = "{{ sort }}";
+    let loading = false;
+
+    async function loadMorePosts() {
+        if (loading || page >= totalPages) return;
+        loading = true;
+        page += 1;
+        try {
+            const response = await fetch(`/load_posts?by=${by}&sort=${sort}&page=${page}`);
+            if (response.ok) {
+                const html = await response.text();
+                postsContainer.insertAdjacentHTML('beforeend', html);
+            }
+        } finally {
+            loading = false;
+        }
+    }
+
+    window.addEventListener('scroll', () => {
+        if (window.innerHeight + window.scrollY >= document.body.offsetHeight - 100) {
+            loadMorePosts();
+        }
+    });
+
+    async function refreshPosts() {
+        const count = postsContainer.children.length;
+        try {
+            const response = await fetch(`/load_posts?by=${by}&sort=${sort}&page=1&limit=${count}`);
+            if (response.ok) {
+                const html = await response.text();
+                postsContainer.innerHTML = html;
+            }
+        } catch (e) {
+            console.error(e);
+        }
+    }
+
+    setInterval(refreshPosts, 10000);
+</script>
 {% endblock body %}


### PR DESCRIPTION
## Summary
- Fetch additional posts on scroll using a new `/load_posts` endpoint
- Default homepage sort to most viewed posts
- Replace pagination controls with JavaScript-based infinite scrolling
- Poll for updated rankings so new or popular posts reorder automatically

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae60376fa48327834b3f0da6f6727f