### PR TITLE
Add NLTK dependency for comment tree

### DIFF
--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -17,5 +17,6 @@ dependencies = [
     "bleach",
     "html2text",
     "networkx",
+    "nltk",
     "scikit-learn",
 ]


### PR DESCRIPTION
## Summary
- add missing nltk dependency so comment similarity tree works

## Testing
- `uv run python - <<'PY'
from utils.commentTree import build_comment_tree
print(build_comment_tree([(1, 'a', 'I love this!'), (2, 'b', 'Terrible experience')]))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68ae77cf9fbc83279514f2f02ce0a936