### PR TITLE
Improve comment tree hover and real-time updates

### DIFF
--- a/app/static/css/commentTree.css
+++ b/app/static/css/commentTree.css
@@ -1,3 +1,7 @@
+#comment-tree {
+  position: relative;
+}
+
 #comment-tree svg {
   width: 100%;
   height: auto;
@@ -12,6 +16,12 @@
   fill: none;
 }
 
+#comment-tree .link-hover {
+  stroke: transparent;
+  stroke-width: 20px;
+  fill: none;
+}
+
 #comment-tree .node {
   fill: #f43f5e;
   stroke: #fb7185;
@@ -22,4 +32,14 @@
 
 #comment-tree .node:hover {
   fill: #be123c;
+}
+
+#comment-tree #branch-legend {
+  position: absolute;
+  top: 0;
+  right: 0;
+  background: rgba(255, 255, 255, 0.8);
+  padding: 4px;
+  pointer-events: none;
+  font-size: 0.875rem;
 }

--- a/app/static/js/post.js
+++ b/app/static/js/post.js
@@ -34,7 +34,8 @@ function fetchCommentTree() {
 
 if (typeof postUrlID !== "undefined") {
   fetchCommentTree();
-  setInterval(fetchCommentTree, 5000);
+  const evtSource = new EventSource(`/post/${postUrlID}/comments/stream`);
+  evtSource.onmessage = () => fetchCommentTree();
 }
 
 function renderCommentTree(data) {
@@ -80,15 +81,23 @@ function renderCommentTree(data) {
     .angle((d) => d.x)
     .radius((d) => d.y);
 
-  svg
+  const links = svg
     .append("g")
-    .selectAll("path")
+    .selectAll("g")
     .data(root.links())
-    .join("path")
+    .join("g");
+
+  links
+    .append("path")
     .attr("class", "link")
+    .attr("d", linkGen);
+
+  links
+    .append("path")
+    .attr("class", "link-hover")
     .attr("d", linkGen)
-    .on("mouseover", (_, d) => showBranch(d.target))
-    .on("mouseout", showAll);
+    .on("mouseenter", (_, d) => showBranch(d.target))
+    .on("mouseleave", showAll);
 
   svg
     .append("g")
@@ -125,7 +134,8 @@ function renderCommentTree(data) {
     document.querySelectorAll("[data-comment-id]").forEach((el) => {
       el.style.display = "";
     });
-    document.getElementById("branch-legend").textContent = "";
+    document.getElementById("branch-legend").textContent =
+      "Hover near a branch to see details";
   }
 
   showAll();

--- a/app/templates/post.html
+++ b/app/templates/post.html
@@ -158,8 +158,9 @@
     </div>
     {% endif %}
 
-    <div id="comment-tree" class="w-full my-4"></div>
-    <div id="branch-legend" class="text-center text-sm mb-4"></div>
+    <div id="comment-tree" class="w-full my-4">
+        <div id="branch-legend" class="text-sm"></div>
+    </div>
     <div class="flex justify-end gap-4">
         <a
             href="{{ url_for('post.post', urlID=urlID, sort='new') }}"


### PR DESCRIPTION
## Summary
- Enlarge comment tree link hit area with invisible overlays and keep legend fixed inside tree
- Replace polling with server-sent events to refresh comment tree when new comments arrive
- Show helpful legend placeholder when not hovering a branch

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae79b24b4c8327aa0ffeaacb507f6e