### PR TITLE
Smooth comment branch transitions

### DIFF
--- a/app/static/css/commentTree.css
+++ b/app/static/css/commentTree.css
@@ -14,7 +14,7 @@
 
 #comment-tree .link {
   stroke: #9ca3af;
-  stroke-width: 1.5px;
+  stroke-width: 3px;
   fill: none;
 }
 
@@ -45,4 +45,20 @@
   pointer-events: none;
   font-size: 0.875rem;
   z-index: 1;
+}
+
+[data-comment-id] {
+  transition: max-height 0.4s ease, opacity 0.4s ease, margin 0.4s ease,
+    padding 0.4s ease;
+  max-height: 1000px;
+  overflow: hidden;
+}
+
+.hidden-comment {
+  opacity: 0;
+  max-height: 0;
+  margin-top: 0 !important;
+  margin-bottom: 0 !important;
+  padding-top: 0 !important;
+  padding-bottom: 0 !important;
 }

--- a/app/static/js/post.js
+++ b/app/static/js/post.js
@@ -116,11 +116,16 @@ function renderCommentTree(data) {
 
   container.on("mouseleave", showAll);
 
-  function showBranch(d) {
-    const ids = d.descendants().map((n) => n.data.id);
+  function animateComments(ids) {
     document.querySelectorAll("[data-comment-id]").forEach((el) => {
-      el.style.display = ids.includes(parseInt(el.dataset.commentId)) ? "" : "none";
+      const show = ids.has(parseInt(el.dataset.commentId));
+      el.classList.toggle("hidden-comment", !show);
     });
+  }
+
+  function showBranch(d) {
+    const ids = new Set(d.descendants().map((n) => n.data.id));
+    animateComments(ids);
     const keywords = d.data.keywords || [];
     const sentiments = d.descendants().map((n) => n.data.sentiment || 0);
     const avgSent =
@@ -133,11 +138,7 @@ function renderCommentTree(data) {
   }
 
   function showAll() {
-    document.querySelectorAll("[data-comment-id]").forEach((el) => {
-      el.style.display = treeCommentIds.has(parseInt(el.dataset.commentId))
-        ? ""
-        : "none";
-    });
+    animateComments(treeCommentIds);
     legend.textContent = "Hover near a branch to see details";
   }
 


### PR DESCRIPTION
## Summary
- Fade out and collapse filtered comments to avoid page jumps
- Animate comment filtering while hovering branches
- Thicken comment tree branches for better visibility

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae7d9c38388327bc677a07661a9c3d