### PR TITLE
Persist selected theme across sessions

### DIFF
--- a/app/static/js/readerControls.js
+++ b/app/static/js/readerControls.js
@@ -2,9 +2,18 @@ document.addEventListener('DOMContentLoaded', () => {
   const root = document.documentElement;
 
   // Theme handling
+  const initialTheme = root.getAttribute('data-theme');
   const storedTheme = localStorage.getItem('theme');
   const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-  const theme = storedTheme || (prefersDark ? 'dark' : 'light');
+
+  let theme = storedTheme || initialTheme || (prefersDark ? 'dark' : 'light');
+
+  // If the server provided a different theme, sync it to localStorage
+  if (initialTheme && initialTheme !== storedTheme) {
+    theme = initialTheme;
+    localStorage.setItem('theme', theme);
+  }
+
   root.setAttribute('data-theme', theme);
 
   const themeToggle = document.getElementById('theme-toggle');


### PR DESCRIPTION
## Summary
- Sync server-side theme changes with localStorage so selected CSS themes persist

## Testing
- `node --check app/static/js/readerControls.js && echo "Syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_68ae8a9b2d788327bcc51e83b966c8e1