### PR TITLE
Store image magnet URLs on-chain and render via WebTorrent

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Sponsored by [CreateMyBanner](https://createmybanner.com)
 - **Analytics** – Tracks post views, visitor countries, and operating systems
 - **Security** - Google reCAPTCHA v3, secure authentication
 - **Advanced Logging** - Powered by [Tamga](https://github.com/dogukanurker/tamga) logger
+- **Member Tiers** – Metered paywall with on-chain accounting
+- **Sponsor Blocks** – First‑party ad slots with frequency capping
+- **Tip Jar** – Per‑author and per‑post tipping using Ethereum with a configurable sysop commission
+- **Torrent-backed Media** – Images are also distributed via BitTorrent for load balancing
 
 ## 🚀 Quick Start
 
@@ -38,6 +42,26 @@ uv run app.py
 ```
 
 Visit `http://localhost:1283` in your browser.
+
+### Blockchain
+
+User accounts, tipping and premium features can be managed on-chain via the
+`FlaskBlogPortal` contract located in [`contracts/FlaskBlog.sol`](contracts/FlaskBlog.sol).
+The sysop can set a commission on tips which is automatically routed to the
+sysop address. The provided Python helpers in [`app/blockchain`](app/blockchain)
+illustrate how to interact with a deployment on an Ethereum compatible network
+such as zkSync.
+
+### Static Files via BitTorrent
+
+All images in [`images/`](images/) are served normally by the Flask server but
+are also seeded over BitTorrent for additional distribution. A helper script
+[`scripts/seed_images.py`](scripts/seed_images.py) generates torrents for the
+images and seeds them using `libtorrent`. These torrent files can also be
+loaded into a uTorrent client so the server and peers share the load.
+Magnet URLs for the images are stored on-chain and fetched through the
+`/magnet/<id>` route, then rendered in the browser using WebTorrent and Blob
+URLs for load-balanced delivery.
 
 ### Default Admin Account
 - Username: `admin`

--- a/app/app.py
+++ b/app/app.py
@@ -60,6 +60,9 @@ from routes.login import (
 from routes.logout import (
     logoutBlueprint,
 )
+from routes.magnet import (
+    magnetBlueprint,
+)
 from routes.passwordReset import (
     passwordResetBlueprint,
 )
@@ -289,6 +292,7 @@ app.register_blueprint(adminPanelCommentsBlueprint)
 app.register_blueprint(changeProfilePictureBlueprint)
 app.register_blueprint(analyticsBlueprint)
 app.register_blueprint(returnPostAnalyticsDataBlueprint)
+app.register_blueprint(magnetBlueprint)
 
 
 if __name__ == "__main__":

--- a/app/blockchain/__init__.py
+++ b/app/blockchain/__init__.py
@@ -1,0 +1,74 @@
+"""Blockchain interaction utilities for FlaskBlog.
+
+These helpers show how the application could interact with the
+`FlaskBlogPortal` contract deployed on an Ethereum-compatible network
+(e.g. zkSync). They do not form a complete replacement for the existing
+SQLite database but provide an outline for migration.
+"""
+from dataclasses import dataclass
+from typing import Optional
+
+from web3 import Web3
+from web3.contract import Contract
+
+
+@dataclass
+class BlockchainConfig:
+    rpc_url: str
+    contract_address: str
+    abi: list
+    sysop_key: Optional[str] = None
+
+
+def _connect(cfg: BlockchainConfig) -> Contract:
+    w3 = Web3(Web3.HTTPProvider(cfg.rpc_url))
+    return w3.eth.contract(address=cfg.contract_address, abi=cfg.abi)
+
+
+def register_user(cfg: BlockchainConfig, user_address: str, tier: int) -> str:
+    """Register a user on-chain. Tier values correspond to the `Tier` enum."""
+    contract = _connect(cfg)
+    sysop = contract.functions.sysop().call()
+    tx = contract.functions.registerUser(Web3.to_checksum_address(user_address), tier).build_transaction({
+        "from": sysop,
+        "nonce": 0,
+    })
+    return tx.hex()
+
+
+def send_tip(cfg: BlockchainConfig, author: str, post_id: bytes, amount_wei: int) -> str:
+    contract = _connect(cfg)
+    tx = contract.functions.tip(Web3.to_checksum_address(author), post_id).build_transaction({
+        "from": cfg.contract_address,
+        "value": amount_wei,
+        "nonce": 0,
+    })
+    return tx.hex()
+
+
+def set_sysop_tip_bps(cfg: BlockchainConfig, bps: int) -> str:
+    """Set the tip percentage (in basis points) that goes to the sysop."""
+    contract = _connect(cfg)
+    sysop = contract.functions.sysop().call()
+    tx = contract.functions.setSysopTipBps(bps).build_transaction({
+        "from": sysop,
+        "nonce": 0,
+    })
+    return tx.hex()
+
+
+def set_image_magnet(cfg: BlockchainConfig, image_id: str, magnet_uri: str) -> str:
+    """Store the magnet URI for a static image on-chain."""
+    contract = _connect(cfg)
+    sysop = contract.functions.sysop().call()
+    tx = contract.functions.setImageMagnet(image_id, magnet_uri).build_transaction({
+        "from": sysop,
+        "nonce": 0,
+    })
+    return tx.hex()
+
+
+def get_image_magnet(cfg: BlockchainConfig, image_id: str) -> str:
+    """Fetch the magnet URI for a static image from the chain."""
+    contract = _connect(cfg)
+    return contract.functions.getImageMagnet(image_id).call()

--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -20,4 +20,6 @@ dependencies = [
     "nltk",
     "scikit-learn",
     "gTTS",
+    "web3",
+    "python-libtorrent",
 ]

--- a/app/routes/magnet.py
+++ b/app/routes/magnet.py
@@ -1,0 +1,20 @@
+"""Return magnet URIs for static images via the blockchain contract."""
+
+from flask import Blueprint, jsonify
+
+from settings import Settings
+from blockchain import BlockchainConfig, get_image_magnet
+
+magnetBlueprint = Blueprint("magnet", __name__)
+
+
+@magnetBlueprint.route("/magnet/<string:image_id>")
+def fetch_magnet(image_id: str):
+    """Fetch the magnet URL for ``image_id`` from the smart contract."""
+    cfg = BlockchainConfig(
+        rpc_url=Settings.BLOCKCHAIN_RPC_URL,
+        contract_address=Settings.BLOCKCHAIN_CONTRACT_ADDRESS,
+        abi=Settings.BLOCKCHAIN_ABI,
+    )
+    magnet = get_image_magnet(cfg, image_id)
+    return jsonify({"magnet": magnet})

--- a/app/settings.py
+++ b/app/settings.py
@@ -143,3 +143,8 @@ class Settings:
     RECAPTCHA_SITE_KEY = ""
     RECAPTCHA_SECRET_KEY = ""
     RECAPTCHA_VERIFY_URL = "https://www.google.com/recaptcha/api/siteverify"
+
+    # Blockchain Configuration
+    BLOCKCHAIN_RPC_URL = "http://localhost:8545"
+    BLOCKCHAIN_CONTRACT_ADDRESS = "0x0000000000000000000000000000000000000000"
+    BLOCKCHAIN_ABI = []

--- a/app/static/js/magnet.js
+++ b/app/static/js/magnet.js
@@ -1,0 +1,28 @@
+(async () => {
+    if (typeof WebTorrent === "undefined") {
+        await new Promise((resolve) => {
+            const s = document.createElement("script");
+            s.src = "https://cdn.jsdelivr.net/npm/webtorrent@latest/webtorrent.min.js";
+            s.onload = resolve;
+            document.head.appendChild(s);
+        });
+    }
+    const client = new WebTorrent();
+    const images = document.querySelectorAll("[data-magnet-id]");
+    for (const img of images) {
+        const id = img.dataset.magnetId;
+        try {
+            const res = await fetch(`/magnet/${id}`);
+            const data = await res.json();
+            client.add(data.magnet, (torrent) => {
+                torrent.files[0].getBlob((err, blob) => {
+                    if (!err) {
+                        img.src = URL.createObjectURL(blob);
+                    }
+                });
+            });
+        } catch (e) {
+            console.error("Failed to load magnet", id, e);
+        }
+    }
+})();

--- a/app/templates/components/navbar.html
+++ b/app/templates/components/navbar.html
@@ -3,7 +3,7 @@
 >
     <a href="/" class="duration-150">
         <img
-            src="https://raw.githubusercontent.com/DogukanUrker/flaskBlog/main/images/Icon180.ico"
+            data-magnet-id="Icon180.ico"
             class="rounded w-14 hover:scale-110 duration-150 shadow"
         />
     </a>

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -79,6 +79,7 @@
         <script src="{{ url_for('static', filename='js/timeStamp.js') }}"></script>
         <script src="{{ url_for('static', filename='js/readerControls.js') }}"></script>
         <script src="{{ url_for('static', filename='js/progress.js') }}"></script>
+        <script src="{{ url_for('static', filename='js/magnet.js') }}"></script>
         <link
             rel="stylesheet"
             href="{{ url_for('static', filename='css/recaptcha.css') }}"

--- a/contracts/FlaskBlog.sol
+++ b/contracts/FlaskBlog.sol
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title FlaskBlogPortal
+/// @notice Stores user accounts, membership tiers, sponsor slots and tip jars on-chain.
+contract FlaskBlogPortal {
+    enum Tier { Free, Premium, Pro }
+
+    struct User {
+        Tier tier;
+        uint256 freeViewsUsed;
+    }
+
+    struct SponsorSlot {
+        address sponsor;
+        uint256 impressions;
+        uint256 maxImpressions;
+    }
+
+    address public sysop;
+    uint256 public nextSponsorSlot;
+    uint256 public sysopTipBps; // tip commission for sysop in basis points (1/100 of a percent)
+
+    mapping(address => User) public users;
+    mapping(uint256 => SponsorSlot) public sponsorSlots;
+    mapping(bytes32 => uint256) public tips; // author+post id => total tips
+    mapping(Tier => uint256) public freeQuota;
+    mapping(string => string) public imageMagnets; // static file id => magnet URI
+
+    event UserRegistered(address indexed user, Tier tier);
+    event TierChanged(address indexed user, Tier tier);
+    event ViewRecorded(address indexed user, uint256 viewsUsed);
+    event TipsSent(address indexed from, address indexed to, bytes32 indexed postId, uint256 amount, uint256 sysopFee);
+    event SponsorSlotCreated(uint256 indexed slotId, uint256 maxImpressions);
+    event SponsorSlotPurchased(uint256 indexed slotId, address indexed sponsor);
+    event ImpressionRecorded(uint256 indexed slotId, uint256 impressions);
+    event ImageMagnetSet(string indexed imageId, string magnetURI);
+
+    modifier onlySysop() {
+        require(msg.sender == sysop, "only sysop");
+        _;
+    }
+
+    constructor() {
+        sysop = msg.sender;
+        freeQuota[Tier.Free] = 3; // default: 3 free views/month
+        freeQuota[Tier.Premium] = 10;
+        freeQuota[Tier.Pro] = type(uint256).max; // unlimited
+        sysopTipBps = 0; // default: no commission
+    }
+
+    /// @notice Sets the percentage of each tip that goes to the sysop (in basis points).
+    function setSysopTipBps(uint256 bps) external onlySysop {
+        require(bps <= 10_000, "bps too high");
+        sysopTipBps = bps;
+    }
+
+    function registerUser(address user, Tier tier) external onlySysop {
+        users[user] = User(tier, 0);
+        emit UserRegistered(user, tier);
+    }
+
+    function setTier(address user, Tier tier) external onlySysop {
+        users[user].tier = tier;
+        emit TierChanged(user, tier);
+    }
+
+    /// @notice Records a view for paywall metering. Returns true if the user still has free views left.
+    function recordView(address user) external onlySysop returns (bool allowed) {
+        User storage u = users[user];
+        u.freeViewsUsed += 1;
+        emit ViewRecorded(user, u.freeViewsUsed);
+        return u.freeViewsUsed <= freeQuota[u.tier];
+    }
+
+    function resetViews(address user) external onlySysop {
+        users[user].freeViewsUsed = 0;
+    }
+
+    /// @notice Tip an author for a specific post. A portion goes to the sysop.
+    /// @param author Recipient address.
+    /// @param postId Arbitrary identifier for the post.
+    function tip(address author, bytes32 postId) external payable {
+        require(msg.value > 0, "no value");
+        uint256 fee = (msg.value * sysopTipBps) / 10_000;
+        uint256 payout = msg.value - fee;
+        if (fee > 0) {
+            (bool feeSent, ) = sysop.call{value: fee}("");
+            require(feeSent, "fee failed");
+        }
+        (bool sent, ) = author.call{value: payout}("");
+        require(sent, "tip failed");
+        tips[keccak256(abi.encodePacked(author, postId))] += payout;
+        emit TipsSent(msg.sender, author, postId, payout, fee);
+    }
+
+    /// @notice Creates a new sponsor slot available for purchase.
+    function createSponsorSlot(uint256 maxImpressions) external onlySysop returns (uint256 slotId) {
+        slotId = nextSponsorSlot++;
+        sponsorSlots[slotId] = SponsorSlot({sponsor: address(0), impressions: 0, maxImpressions: maxImpressions});
+        emit SponsorSlotCreated(slotId, maxImpressions);
+    }
+
+    /// @notice Purchase a sponsor slot. Payment handled off-chain.
+    function buySponsorSlot(uint256 slotId) external {
+        SponsorSlot storage slot = sponsorSlots[slotId];
+        require(slot.sponsor == address(0), "taken");
+        slot.sponsor = msg.sender;
+        emit SponsorSlotPurchased(slotId, msg.sender);
+    }
+
+    /// @notice Records an impression for a sponsor slot. Resets when max is reached.
+    function recordImpression(uint256 slotId) external onlySysop {
+        SponsorSlot storage slot = sponsorSlots[slotId];
+        require(slot.sponsor != address(0), "no sponsor");
+        slot.impressions += 1;
+        emit ImpressionRecorded(slotId, slot.impressions);
+        if (slot.impressions >= slot.maxImpressions) {
+            slot.sponsor = address(0);
+            slot.impressions = 0;
+        }
+    }
+
+    /// @notice Store the magnet URI for a static file.
+    /// @param imageId Identifier of the image (e.g. filename).
+    /// @param magnetURI Magnet link pointing to the file's torrent.
+    function setImageMagnet(string calldata imageId, string calldata magnetURI) external onlySysop {
+        imageMagnets[imageId] = magnetURI;
+        emit ImageMagnetSet(imageId, magnetURI);
+    }
+
+    /// @notice Fetch the magnet URI for a static file.
+    function getImageMagnet(string calldata imageId) external view returns (string memory) {
+        return imageMagnets[imageId];
+    }
+}

--- a/scripts/seed_images.py
+++ b/scripts/seed_images.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+import libtorrent as lt
+
+from app.blockchain import BlockchainConfig, set_image_magnet
+from app.settings import Settings
+
+
+def seed_images(image_dir: str = "images") -> None:
+    """Create and seed torrents for images in ``image_dir``.
+
+    The server continues to host the original files, while seeding them on
+    BitTorrent for additional distribution capacity.
+    """
+    ses = lt.session()
+    ses.listen_on(6881, 6891)
+    cfg = BlockchainConfig(
+        rpc_url=Settings.BLOCKCHAIN_RPC_URL,
+        contract_address=Settings.BLOCKCHAIN_CONTRACT_ADDRESS,
+        abi=Settings.BLOCKCHAIN_ABI,
+    )
+    for img in Path(image_dir).glob("*"):
+        if img.is_file():
+            fs = lt.file_storage()
+            lt.add_files(fs, str(img))
+            t = lt.create_torrent(fs)
+            t.add_tracker("udp://tracker.openbittorrent.com:80")
+            lt.set_piece_hashes(t, str(img.parent))
+            torrent = t.generate()
+            torrent_path = img.with_suffix(img.suffix + ".torrent")
+            with open(torrent_path, "wb") as f:
+                f.write(lt.bencode(torrent))
+            ti = lt.torrent_info(torrent_path)
+            ses.add_torrent({"ti": ti, "save_path": str(img.parent)})
+            magnet = lt.make_magnet_uri(ti)
+            tx = set_image_magnet(cfg, img.name, magnet)
+            print(
+                f"Seeding {img.name} (torrent: {torrent_path.name}) - stored magnet tx {tx}"
+            )
+    print("Seeding started. Keep this process running to continue seeding.")
+
+
+if __name__ == "__main__":
+    seed_images()


### PR DESCRIPTION
## Summary
- map static image IDs to magnet URIs in `FlaskBlogPortal` with helper functions
- expose `/magnet/<id>` route and client script that fetches magnet links and loads images via WebTorrent
- seed script now publishes magnets on-chain and docs describe BitTorrent + magnet workflow

## Testing
- `pip install python-libtorrent` *(fails: No matching distribution found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae8b9c96d48327b9a209145b41827c