### PR TITLE
Fix libtorrent dependency for torrent-based images

### DIFF
--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -21,5 +21,5 @@ dependencies = [
     "scikit-learn",
     "gTTS",
     "web3",
-    "python-libtorrent",
+    "libtorrent",
 ]


### PR DESCRIPTION
## Summary
- replace the non-existent `python-libtorrent` package with `libtorrent`

## Testing
- `uv run -p 3.10 --project app app/app.py`

------
https://chatgpt.com/codex/tasks/task_e_68ae8f3a10388327855f5b8a017c8c33