### PR TITLE
Gate admin features behind wallet check and handle RPC failures

### DIFF
--- a/app/blockchain/__init__.py
+++ b/app/blockchain/__init__.py
@@ -102,5 +102,8 @@ def set_image_magnet(cfg: BlockchainConfig, image_id: str, magnet_uri: str) -> s
 def get_image_magnet(cfg: BlockchainConfig, image_id: str) -> str:
     """Fetch the magnet URI for a static image from the chain."""
     contract = _connect(cfg)
-    return contract.functions.getImageMagnet(image_id).call()
+    try:
+        return contract.functions.getImageMagnet(image_id).call()
+    except Exception:
+        return ""
 

--- a/app/routes/adminPanel.py
+++ b/app/routes/adminPanel.py
@@ -26,7 +26,7 @@ def adminPanel():
 
             Log.info("Rendering adminPanel.html: params: None")
 
-            return render_template("adminPanel.html")
+            return render_template("adminPanel.html", admin_check=True)
         else:
             Log.error(
                 f"{request.remote_addr} tried to reach admin panel without being admin"

--- a/app/routes/adminPanelContracts.py
+++ b/app/routes/adminPanelContracts.py
@@ -37,7 +37,9 @@ def adminPanelContracts():
                     Settings.BLOCKCHAIN_CONTRACTS[name]["address"] = address
             Log.info("Rendering adminPanelContracts.html")
             return render_template(
-                "adminPanelContracts.html", contracts=Settings.BLOCKCHAIN_CONTRACTS
+                "adminPanelContracts.html",
+                contracts=Settings.BLOCKCHAIN_CONTRACTS,
+                admin_check=True,
             )
         Log.error(
             f"{request.remote_addr} tried to reach contracts admin panel without being admin"

--- a/app/routes/adminPanelPosts.py
+++ b/app/routes/adminPanelPosts.py
@@ -1,3 +1,5 @@
+import sqlite3
+
 from flask import (
     Blueprint,
     redirect,
@@ -18,37 +20,52 @@ adminPanelPostsBlueprint = Blueprint("adminPanelPosts", __name__)
 def adminPanelPosts():
     if "userName" in session:
         Log.info(f"Admin: {session['userName']} reached to posts admin panel")
-        Log.database(f"Connecting to '{Settings.DB_POSTS_ROOT}' database")
-
-        if request.method == "POST":
-            if "postDeleteButton" in request.form:
-                Log.info(
-                    f"Admin: {session['userName']} deleted post: {request.form['postID']}"
-                )
-                Delete.post(request.form["postID"])
-
-                return redirect("/admin/posts")
-
-        posts, page, total_pages = paginate_query(
-            Settings.DB_POSTS_ROOT,
-            "select count(*) from posts",
-            "select * from posts order by timeStamp desc",
+        Log.database(f"Connecting to '{Settings.DB_USERS_ROOT}' database")
+        connection = sqlite3.connect(Settings.DB_USERS_ROOT)
+        connection.set_trace_callback(Log.database)
+        cursor = connection.cursor()
+        cursor.execute(
+            """select role from users where userName = ? """,
+            [(session["userName"])],
         )
+        role = cursor.fetchone()[0]
 
-        Log.info(
-            f"Rendering dashboard.html: params: posts={len(posts)} and showPosts=True"
-        )
+        if role == "admin":
+            Log.database(f"Connecting to '{Settings.DB_POSTS_ROOT}' database")
 
-        return render_template(
-            "dashboard.html",
-            posts=posts,
-            showPosts=True,
-            page=page,
-            total_pages=total_pages,
-        )
-    else:
+            if request.method == "POST":
+                if "postDeleteButton" in request.form:
+                    Log.info(
+                        f"Admin: {session['userName']} deleted post: {request.form['postID']}"
+                    )
+                    Delete.post(request.form["postID"])
+
+                    return redirect("/admin/posts")
+
+            posts, page, total_pages = paginate_query(
+                Settings.DB_POSTS_ROOT,
+                "select count(*) from posts",
+                "select * from posts order by timeStamp desc",
+            )
+
+            Log.info(
+                f"Rendering dashboard.html: params: posts={len(posts)} and showPosts=True"
+            )
+
+            return render_template(
+                "dashboard.html",
+                posts=posts,
+                showPosts=True,
+                page=page,
+                total_pages=total_pages,
+                admin_check=True,
+            )
         Log.error(
-            f"{request.remote_addr} tried to reach post admin panel being logged in"
+            f"{request.remote_addr} tried to reach post admin panel without being admin"
         )
-
         return redirect("/")
+    Log.error(
+        f"{request.remote_addr} tried to reach post admin panel being logged in"
+    )
+
+    return redirect("/")

--- a/app/routes/adminPanelUsers.py
+++ b/app/routes/adminPanelUsers.py
@@ -61,6 +61,7 @@ def adminPanelUsers():
                 users=users,
                 page=page,
                 total_pages=total_pages,
+                admin_check=True,
             )
         else:
             Log.error(

--- a/app/routes/magnet.py
+++ b/app/routes/magnet.py
@@ -4,6 +4,8 @@ from flask import Blueprint, jsonify
 
 from settings import Settings
 from blockchain import BlockchainConfig, get_image_magnet
+from requests.exceptions import RequestException
+
 
 magnetBlueprint = Blueprint("magnet", __name__)
 
@@ -17,5 +19,8 @@ def fetch_magnet(image_id: str):
         contract_address=contract["address"],
         abi=contract["abi"],
     )
-    magnet = get_image_magnet(cfg, image_id)
+    try:
+        magnet = get_image_magnet(cfg, image_id)
+    except Exception:
+        magnet = ""
     return jsonify({"magnet": magnet})

--- a/app/static/js/adminCheck.js
+++ b/app/static/js/adminCheck.js
@@ -1,0 +1,5 @@
+(function() {
+    if (!document.body.classList.contains('admin-wallet')) {
+        window.location.replace('/');
+    }
+})();

--- a/app/static/js/wallet.js
+++ b/app/static/js/wallet.js
@@ -1,0 +1,31 @@
+const ADMIN_ADDRESS = "0xB2b36AaD18d7be5d4016267BC4cCec2f12a64b6e".toLowerCase();
+
+async function connectWallet() {
+    if (typeof window.ethereum === 'undefined') {
+        return;
+    }
+    try {
+        const accounts = await window.ethereum.request({ method: 'eth_requestAccounts' });
+        const account = accounts[0]?.toLowerCase();
+        if (!account) {
+            return;
+        }
+        window.userAddress = account;
+        const uname = document.getElementById('userName');
+        if (uname && !uname.value) {
+            uname.value = account;
+            uname.readOnly = true;
+        }
+        const submitBtn = document.getElementById('signup-btn');
+        if (submitBtn) {
+            submitBtn.disabled = false;
+        }
+        if (account === ADMIN_ADDRESS) {
+            document.body.classList.add('admin-wallet');
+        }
+    } catch (err) {
+        console.error('Wallet connection failed', err);
+    }
+}
+
+window.addEventListener('load', connectWallet);

--- a/app/templates/adminPanel.html
+++ b/app/templates/adminPanel.html
@@ -1,4 +1,4 @@
-{% extends 'layout.html' %} {% block head %}
+{% extends 'layout.html' %} {% set admin_check = True %} {% block head %}
 <title>{{translations.adminPanel.title }}</title>
 {% endblock head %} {% block body %}
 <div class="w-fit mx-auto mt-32 text-center text-2xl font-medium">

--- a/app/templates/adminPanelComments.html
+++ b/app/templates/adminPanelComments.html
@@ -1,4 +1,4 @@
-{% extends 'layout.html' %} {% block head %}
+{% extends 'layout.html' %} {% set admin_check = True %} {% block head %}
 <title>{{translations.adminPanelComments.title}}</title>
 {% endblock head %} {% block body %}
 <h1 class="my-4 text-4xl font-medium select-none text-center">

--- a/app/templates/adminPanelContracts.html
+++ b/app/templates/adminPanelContracts.html
@@ -1,4 +1,4 @@
-{% extends 'layout.html' %}
+{% extends 'layout.html' %} {% set admin_check = True %}
 {% block head %}
 <title>{{ translations.get('adminPanelContracts', {}).get('title', 'Admin Panel - Contracts') }}</title>
 {% endblock head %}

--- a/app/templates/adminPanelUsers.html
+++ b/app/templates/adminPanelUsers.html
@@ -1,4 +1,4 @@
-{% extends 'layout.html' %} {% block head %}
+{% extends 'layout.html' %} {% set admin_check = True %} {% block head %}
 <title>{{translations.adminPanelUsers.title}}</title>
 {% endblock head %} {% block body %}
 <div class="text-center">

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -75,7 +75,12 @@
             integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n"
             crossorigin="anonymous"
         ></script>
-        
+
+        <script src="{{ url_for('static', filename='js/wallet.js') }}"></script>
+        {% if admin_check %}
+        <script src="{{ url_for('static', filename='js/adminCheck.js') }}"></script>
+        {% endif %}
+
         <script src="{{ url_for('static', filename='js/timeStamp.js') }}"></script>
         <script src="{{ url_for('static', filename='js/readerControls.js') }}"></script>
         <script src="{{ url_for('static', filename='js/progress.js') }}"></script>

--- a/app/templates/signup.html
+++ b/app/templates/signup.html
@@ -22,7 +22,9 @@
                     >
                     {{form.userName(class_="input input-bordered w-full",
                     autocomplete="off",
-                    placeholder=translations.signup.username)}}
+                    placeholder=translations.signup.username,
+                    readonly=True,
+                    id="userName")}}
                     <label class="label">{{translations.signup.email}}</label>
                     {{form.email(class_="input input-bordered w-full",
                     autocomplete="off", placeholder=translations.signup.email)}}
@@ -40,6 +42,8 @@
                         data-callback="onSubmit"
                         data-action="submit"
                         class="g-recaptcha btn btn-neutral mt-4"
+                        id="signup-btn"
+                        disabled
                     >
                         {{translations.signup.title}}
                     </button>
@@ -67,7 +71,9 @@
                     >
                     {{form.userName(class_="input input-bordered w-full",
                     autocomplete="off",
-                    placeholder=translations.signup.username)}}
+                    placeholder=translations.signup.username,
+                    readonly=True,
+                    id="userName")}}
                     <label class="label">{{translations.signup.email}}</label>
                     {{form.email(class_="input input-bordered w-full",
                     autocomplete="off", placeholder=translations.signup.email)}}
@@ -79,7 +85,7 @@
                     <label class="label">{{translations.signup.confirm}}</label>
                     {{form.passwordConfirm(class_="input input-bordered w-full",
                     placeholder=translations.signup.confirm)}}
-                    <button type="submit" class="btn btn-neutral mt-4">
+                    <button type="submit" class="btn btn-neutral mt-4" id="signup-btn" disabled>
                         {{translations.signup.title}}
                     </button>
                     <div class="text-xs select-none mt-2 w-full text-center">


### PR DESCRIPTION
## Summary
- Detect MetaMask account and expose admin features only for 0xB2b36AaD18d7be5d4016267BC4cCec2f12a64b6e
- Require connected wallet on sign up and guard admin panels client-side
- Gracefully handle missing blockchain RPC node when retrieving magnet links

## Testing
- `python -m py_compile app/blockchain/__init__.py app/routes/adminPanel.py app/routes/adminPanelComments.py app/routes/adminPanelContracts.py app/routes/adminPanelPosts.py app/routes/adminPanelUsers.py app/routes/magnet.py`

------
https://chatgpt.com/codex/tasks/task_e_68aea0ffffd0832783fdfb77c51d5700