### PR TITLE
Use query redirect for login and default to home

### DIFF
--- a/app/routes/accountSettings.py
+++ b/app/routes/accountSettings.py
@@ -35,4 +35,4 @@ def accountSettings():
             f"{request.remote_addr} tried to reach account settings without being logged in"
         )
 
-        return redirect("/login/redirect=&accountsettings")
+        return redirect("/login?redirect=/accountsettings")

--- a/app/routes/changePassword.py
+++ b/app/routes/changePassword.py
@@ -93,7 +93,7 @@ def changePassword():
                         language=language,
                     )
 
-                    return redirect("/login/redirect=&")
+                    return redirect("/login?redirect=/")
             else:
                 flashMessage(
                     page="changePassword",
@@ -117,4 +117,4 @@ def changePassword():
             language=language,
         )
 
-        return redirect("/login/redirect=changepassword")
+        return redirect("/login?redirect=/changepassword")

--- a/app/routes/createPost.py
+++ b/app/routes/createPost.py
@@ -179,4 +179,4 @@ def createPost():
             category="error",
             language=session["language"],
         )
-        return redirect("/login/redirect=&createpost")
+        return redirect("/login?redirect=/createpost")

--- a/app/routes/dashboard.py
+++ b/app/routes/dashboard.py
@@ -96,4 +96,4 @@ def dashboard(userName):
             language=session["language"],
         )
 
-        return redirect("/login/redirect=&dashboard&user")
+        return redirect("/login?redirect=/dashboard/user")

--- a/app/routes/editPost.py
+++ b/app/routes/editPost.py
@@ -214,4 +214,4 @@ def editPost(urlID):
             category="error",
             language=session["language"],
         )
-        return redirect(f"/login/redirect=&editpost&{urlID}")
+        return redirect(f"/login?redirect=/editpost/{urlID}")

--- a/app/routes/login.py
+++ b/app/routes/login.py
@@ -9,10 +9,10 @@ loginBlueprint = Blueprint("login", __name__)
 LOGIN_MESSAGE = "Log in to FlaskBlog"
 
 
-@loginBlueprint.route("/login/redirect=<direct>", methods=["GET", "POST"])
-def login(direct):
+@loginBlueprint.route("/login", methods=["GET", "POST"])
+def login():
     """Handle MetaMask based login."""
-    direct = direct.replace("&", "/")
+    direct = request.args.get("redirect", "/")
     if not Settings.LOG_IN:
         return redirect(direct), 301
     if "walletAddress" in session:

--- a/app/routes/passwordReset.py
+++ b/app/routes/passwordReset.py
@@ -83,7 +83,7 @@ def passwordReset(codeSent):
                             category="success",
                             language=session["language"],
                         )
-                        return redirect("/login/redirect=&")
+                        return redirect("/login?redirect=/")
                 else:
                     flashMessage(
                         page="passwordReset",

--- a/app/static/js/metamaskLogin.js
+++ b/app/static/js/metamaskLogin.js
@@ -11,7 +11,7 @@ async function loginWithMetaMask(redirectUrl) {
             method: 'personal_sign',
             params: [message, address],
         });
-        const resp = await fetch(`/login/redirect=${encodeURIComponent(redirectUrl)}`, {
+        const resp = await fetch(`/login?redirect=${encodeURIComponent(redirectUrl)}`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ address, signature }),

--- a/app/templates/components/navbar.html
+++ b/app/templates/components/navbar.html
@@ -57,13 +57,13 @@
             </button>
         </a>
         {% endif %} {% elif hideSignUp %} {% if isLogin %}
-        <a href="/login/redirect=&">
+        <a href="/login">
             <button class="hover:text-rose-500 duration-150">
                 <i class="ti ti-login text-2xl"></i>
             </button>
         </a>
         {% endif %} {% else %} {% if isLogin %}
-        <a href="/login/redirect=&">
+        <a href="/login">
             <button class="hover:text-rose-500 duration-150">
                 <i class="ti ti-login text-2xl"></i>
             </button>


### PR DESCRIPTION
## Summary
- simplify login route to /login and default redirect to /
- update MetaMask login script and templates to use query redirect
- refresh route redirects and navbar links for new login endpoint

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68aea4fd18f0832798e164c365ed6fef