### PR TITLE
Fix MetaMask login CSRF handling

### DIFF
--- a/app/static/js/metamaskLogin.js
+++ b/app/static/js/metamaskLogin.js
@@ -13,7 +13,7 @@ async function loginWithMetaMask(redirectUrl) {
         });
         const resp = await fetch(`/login?redirect=${encodeURIComponent(redirectUrl)}`, {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
+            headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrfToken },
             body: JSON.stringify({ address, signature }),
         });
         const data = await resp.json();

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -1,6 +1,9 @@
 {% extends 'layout.html'%}
 {%block head%}
 <title>{{translations.login.title}}</title>
+<script>
+    const csrfToken = "{{ csrf_token() }}";
+</script>
 <script src="{{ url_for('static', filename='js/metamaskLogin.js') }}"></script>
 {% endblock head %}
 {%block body%}


### PR DESCRIPTION
## Summary
- inject CSRF token in login page
- send CSRF token with MetaMask login request to satisfy CSRF protection

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aea851c2688327b58369cfb8a05170