### PR TITLE
Load posts via blockchain API and restore categories

### DIFF
--- a/app/routes/category.py
+++ b/app/routes/category.py
@@ -75,4 +75,7 @@ def category(category, by="timeStamp", sort="desc"):
         page=page,
         total_pages=total_pages,
         categories=get_categories(),
+        post_contract_address=Settings.BLOCKCHAIN_CONTRACTS["PostStorage"]["address"],
+        post_contract_abi=Settings.BLOCKCHAIN_CONTRACTS["PostStorage"]["abi"],
+        rpc_url=Settings.BLOCKCHAIN_RPC_URL,
     )

--- a/app/routes/category.py
+++ b/app/routes/category.py
@@ -69,6 +69,7 @@ def category(category, by="timeStamp", sort="desc"):
         "category.html",
         posts=posts,
         category=translations["categories"].get(category.lower(), category),
+        raw_category=category,
         sortName=sortName,
         source=f"/category/{category}",
         page=page,

--- a/app/routes/index.py
+++ b/app/routes/index.py
@@ -18,11 +18,22 @@ purposes without permission is strictly prohibited.
 
 from json import load
 
-from flask import Blueprint, redirect, render_template, session, request
+from flask import (
+    Blueprint,
+    redirect,
+    render_template,
+    session,
+    request,
+    jsonify,
+    url_for,
+)
 from settings import Settings
 from utils.log import Log
 from utils.paginate import paginate_query
 from utils.categories import get_categories
+from utils.generateUrlIdFromPost import getSlugFromPostTitle
+from utils.getProfilePicture import getProfilePicture
+from blockchain import BlockchainConfig, get_image_magnet
 
 indexBlueprint = Blueprint("index", __name__)
 
@@ -100,6 +111,58 @@ def index(by="views", sort="desc"):
         sort=sort,
         categories=get_categories(),
     )
+
+
+@indexBlueprint.route("/api/posts")
+def api_posts():
+    """Return post data along with magnet URIs."""
+    category = request.args.get("category")
+
+    base_select = (
+        "select id, title, author, timeStamp, category, urlID, abstract from posts"
+    )
+    base_count = "select count(*) from posts"
+    params = []
+    if category:
+        base_select += " where lower(category) = ?"
+        base_count += " where lower(category) = ?"
+        params.append(category.lower())
+    base_select += " order by timeStamp desc"
+
+    posts, _, _ = paginate_query(
+        Settings.DB_POSTS_ROOT, base_count, base_select, params, per_page=50
+    )
+
+    contract = Settings.BLOCKCHAIN_CONTRACTS.get("ImageStorage", {})
+    cfg = BlockchainConfig(
+        rpc_url=Settings.BLOCKCHAIN_RPC_URL,
+        contract_address=contract.get("address", "0x0"),
+        abi=contract.get("abi", []),
+    )
+
+    data = []
+    for p in posts:
+        try:
+            magnet = get_image_magnet(cfg, f"{p[0]}.png")
+        except Exception:
+            magnet = ""
+        data.append(
+            {
+                "id": p[0],
+                "title": p[1],
+                "author": p[2],
+                "timestamp": p[3],
+                "category": p[4],
+                "url": url_for(
+                    "post.post", slug=getSlugFromPostTitle(p[1]), urlID=p[5]
+                ),
+                "abstract": p[6],
+                "author_picture": getProfilePicture(p[2]),
+                "magnet": magnet,
+            }
+        )
+
+    return jsonify({"posts": data})
 
 
 @indexBlueprint.route("/load_posts")

--- a/app/templates/category.html
+++ b/app/templates/category.html
@@ -33,15 +33,31 @@
     <br />
 </div>
 
+<script src="https://cdn.jsdelivr.net/npm/ethers@5.7.2/dist/ethers.umd.min.js"></script>
 <script>
+    const rpcUrl = "{{ rpc_url }}";
+    const postContractAddress = "{{ post_contract_address }}";
+    const postContractAbi = {{ post_contract_abi | tojson }};
+    const targetCategory = "{{ raw_category|lower }}";
+
     async function renderCategoryPosts() {
         const container = document.getElementById('posts-container');
         container.innerHTML = '';
         try {
-            const response = await fetch('/api/posts?category={{ raw_category|lower }}');
-            if (!response.ok) return;
-            const data = await response.json();
-            for (const post of data.posts) {
+            const provider = new ethers.providers.JsonRpcProvider(rpcUrl);
+            const contract = new ethers.Contract(postContractAddress, postContractAbi, provider);
+            const nextId = await contract.nextPostId();
+            for (let i = 0; i < nextId; i++) {
+                const onchain = await contract.posts(i);
+                if (!onchain.exists) continue;
+                let meta = {};
+                try {
+                    const metaRes = await fetch(onchain.contentHash);
+                    meta = await metaRes.json();
+                } catch (err) {
+                    console.error(err);
+                }
+                if ((meta.category || '').toLowerCase() !== targetCategory) continue;
                 const card = document.createElement('div');
                 card.className = 'flex flex-col bg-base-200 rounded-box w-[20rem] h-[30rem] hover:scale-105 duration-150';
 
@@ -52,9 +68,9 @@
                 imgWrap.appendChild(img);
                 card.appendChild(imgWrap);
 
-                if (post.magnet) {
+                if (meta.magnet) {
                     try {
-                        const imgRes = await fetch(post.magnet);
+                        const imgRes = await fetch(meta.magnet);
                         const blob = await imgRes.blob();
                         img.src = URL.createObjectURL(blob);
                     } catch (err) {
@@ -67,43 +83,47 @@
 
                 const cat = document.createElement('h3');
                 cat.className = 'text-secondary font-medium text-sm line-clamp-1';
-                cat.textContent = post.category;
+                cat.textContent = meta.category || '';
                 body.appendChild(cat);
 
                 const link = document.createElement('a');
-                link.href = post.url;
+                link.href = meta.url || '#';
                 link.className = 'link link-hover text-xl font-bold line-clamp-2 leading-tight';
-                link.textContent = post.title;
+                link.textContent = meta.title || `Post ${i}`;
                 body.appendChild(link);
 
                 const abstractDiv = document.createElement('div');
                 abstractDiv.className = 'overflow-hidden flex-grow';
                 const abstractSpan = document.createElement('span');
                 abstractSpan.className = 'text-sm leading-relaxed line-clamp-4 break-words';
-                abstractSpan.textContent = post.abstract;
+                abstractSpan.textContent = meta.abstract || '';
                 abstractDiv.appendChild(abstractSpan);
                 body.appendChild(abstractDiv);
 
                 const footer = document.createElement('div');
                 footer.className = 'flex justify-between items-center mt-auto pt-2 w-full';
                 const authorLink = document.createElement('a');
-                authorLink.href = '/user/' + post.author;
+                authorLink.href = '/user/' + (meta.author || onchain.author);
                 authorLink.className = 'flex items-center gap-2 min-w-0';
 
                 const avatar = document.createElement('img');
                 avatar.alt = 'Profile';
-                avatar.src = post.author_picture || '';
+                avatar.src = meta.author_picture || '';
                 avatar.className = 'w-8 h-8 rounded object-cover flex-shrink-0';
                 authorLink.appendChild(avatar);
 
                 const nameSpan = document.createElement('span');
                 nameSpan.className = 'font-medium text-sm truncate';
-                nameSpan.textContent = post.author;
+                nameSpan.textContent = meta.author || onchain.author;
                 authorLink.appendChild(nameSpan);
 
                 const dateSpan = document.createElement('span');
                 dateSpan.className = 'date text-sm flex-shrink-0';
-                dateSpan.textContent = new Date(post.timestamp * 1000).toLocaleDateString();
+                if (meta.timestamp) {
+                    dateSpan.textContent = new Date(meta.timestamp * 1000).toLocaleDateString();
+                } else {
+                    dateSpan.textContent = '';
+                }
 
                 footer.appendChild(authorLink);
                 footer.appendChild(dateSpan);

--- a/app/templates/category.html
+++ b/app/templates/category.html
@@ -16,16 +16,9 @@
 </div>
 
 <div
+    id="posts-container"
     class="flex item-center justify-center flex-wrap gap-x-2 gap-y-6 mx-auto w-11/12 md:w-10/12 lg:w-9/12 2xl:w-8/12 mt-6"
->
-    {% for post in posts %}
-        {% from "components/postCardMacro.html" import postCard with context %}
-        {{ postCard(post=post, authorProfilePicture=getProfilePicture(post[5])) }}
-    {% endfor %}
-</div>
-
-{% from "components/pagination.html" import pagination %}
-{{ pagination(page, total_pages, request.path) }}
+></div>
 
 <div class="text-center mt-4 mb-2 text-xs font-medium">
     <div class="mb-1">
@@ -39,4 +32,91 @@
     {{ translations.about.credits | safe }}
     <br />
 </div>
+
+<script>
+    async function renderCategoryPosts() {
+        const container = document.getElementById('posts-container');
+        container.innerHTML = '';
+        try {
+            const response = await fetch('/api/posts?category={{ raw_category|lower }}');
+            if (!response.ok) return;
+            const data = await response.json();
+            for (const post of data.posts) {
+                const card = document.createElement('div');
+                card.className = 'flex flex-col bg-base-200 rounded-box w-[20rem] h-[30rem] hover:scale-105 duration-150';
+
+                const imgWrap = document.createElement('div');
+                imgWrap.className = 'overflow-hidden flex-shrink-0';
+                const img = document.createElement('img');
+                img.className = 'h-48 w-full group-hover:scale-110 transition duration-150 object-cover rounded-t-md select-none';
+                imgWrap.appendChild(img);
+                card.appendChild(imgWrap);
+
+                if (post.magnet) {
+                    try {
+                        const imgRes = await fetch(post.magnet);
+                        const blob = await imgRes.blob();
+                        img.src = URL.createObjectURL(blob);
+                    } catch (err) {
+                        console.error(err);
+                    }
+                }
+
+                const body = document.createElement('div');
+                body.className = 'flex flex-col gap-4 p-6 flex-grow';
+
+                const cat = document.createElement('h3');
+                cat.className = 'text-secondary font-medium text-sm line-clamp-1';
+                cat.textContent = post.category;
+                body.appendChild(cat);
+
+                const link = document.createElement('a');
+                link.href = post.url;
+                link.className = 'link link-hover text-xl font-bold line-clamp-2 leading-tight';
+                link.textContent = post.title;
+                body.appendChild(link);
+
+                const abstractDiv = document.createElement('div');
+                abstractDiv.className = 'overflow-hidden flex-grow';
+                const abstractSpan = document.createElement('span');
+                abstractSpan.className = 'text-sm leading-relaxed line-clamp-4 break-words';
+                abstractSpan.textContent = post.abstract;
+                abstractDiv.appendChild(abstractSpan);
+                body.appendChild(abstractDiv);
+
+                const footer = document.createElement('div');
+                footer.className = 'flex justify-between items-center mt-auto pt-2 w-full';
+                const authorLink = document.createElement('a');
+                authorLink.href = '/user/' + post.author;
+                authorLink.className = 'flex items-center gap-2 min-w-0';
+
+                const avatar = document.createElement('img');
+                avatar.alt = 'Profile';
+                avatar.src = post.author_picture || '';
+                avatar.className = 'w-8 h-8 rounded object-cover flex-shrink-0';
+                authorLink.appendChild(avatar);
+
+                const nameSpan = document.createElement('span');
+                nameSpan.className = 'font-medium text-sm truncate';
+                nameSpan.textContent = post.author;
+                authorLink.appendChild(nameSpan);
+
+                const dateSpan = document.createElement('span');
+                dateSpan.className = 'date text-sm flex-shrink-0';
+                dateSpan.textContent = new Date(post.timestamp * 1000).toLocaleDateString();
+
+                footer.appendChild(authorLink);
+                footer.appendChild(dateSpan);
+                body.appendChild(footer);
+                card.appendChild(body);
+
+                container.appendChild(card);
+            }
+        } catch (e) {
+            console.error(e);
+        }
+    }
+
+    document.addEventListener('DOMContentLoaded', renderCategoryPosts);
+</script>
 {% endblock body %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -37,12 +37,7 @@
 <div
     id="posts-container"
     class="flex item-center justify-center flex-wrap gap-x-4 gap-y-6 mx-auto w-11/12 md:w-11/12 lg:w-10/12 2xl:w-9/12 mt-6"
->
-    {% for post in posts %}
-        {% from "components/postCardMacro.html" import postCard with context %}
-        {{ postCard(post=post, authorProfilePicture=getProfilePicture(post[5])) }}
-    {% endfor %}
-</div>
+></div>
 
 <div class="text-center mt-4 mb-2 text-xs font-medium">
     <div class="mb-1">
@@ -58,47 +53,89 @@
 </div>
 
 <script>
-    const postsContainer = document.getElementById('posts-container');
-    let page = 1;
-    const totalPages = {{ total_pages }};
-    const by = "{{ by }}";
-    const sort = "{{ sort }}";
-    let loading = false;
-
-    async function loadMorePosts() {
-        if (loading || page >= totalPages) return;
-        loading = true;
-        page += 1;
+    async function renderPosts() {
+        const container = document.getElementById('posts-container');
+        container.innerHTML = '';
         try {
-            const response = await fetch(`/load_posts?by=${by}&sort=${sort}&page=${page}`);
-            if (response.ok) {
-                const html = await response.text();
-                postsContainer.insertAdjacentHTML('beforeend', html);
-            }
-        } finally {
-            loading = false;
-        }
-    }
+            const response = await fetch('/api/posts');
+            if (!response.ok) return;
+            const data = await response.json();
+            for (const post of data.posts) {
+                const card = document.createElement('div');
+                card.className = 'flex flex-col bg-base-200 rounded-box w-[20rem] h-[30rem] hover:scale-105 duration-150';
 
-    window.addEventListener('scroll', () => {
-        if (window.innerHeight + window.scrollY >= document.body.offsetHeight - 100) {
-            loadMorePosts();
-        }
-    });
+                const imgWrap = document.createElement('div');
+                imgWrap.className = 'overflow-hidden flex-shrink-0';
+                const img = document.createElement('img');
+                img.className = 'h-48 w-full group-hover:scale-110 transition duration-150 object-cover rounded-t-md select-none';
+                imgWrap.appendChild(img);
+                card.appendChild(imgWrap);
 
-    async function refreshPosts() {
-        const count = postsContainer.children.length;
-        try {
-            const response = await fetch(`/load_posts?by=${by}&sort=${sort}&page=1&limit=${count}`);
-            if (response.ok) {
-                const html = await response.text();
-                postsContainer.innerHTML = html;
+                if (post.magnet) {
+                    try {
+                        const imgRes = await fetch(post.magnet);
+                        const blob = await imgRes.blob();
+                        img.src = URL.createObjectURL(blob);
+                    } catch (err) {
+                        console.error(err);
+                    }
+                }
+
+                const body = document.createElement('div');
+                body.className = 'flex flex-col gap-4 p-6 flex-grow';
+
+                const cat = document.createElement('h3');
+                cat.className = 'text-secondary font-medium text-sm line-clamp-1';
+                cat.textContent = post.category;
+                body.appendChild(cat);
+
+                const link = document.createElement('a');
+                link.href = post.url;
+                link.className = 'link link-hover text-xl font-bold line-clamp-2 leading-tight';
+                link.textContent = post.title;
+                body.appendChild(link);
+
+                const abstractDiv = document.createElement('div');
+                abstractDiv.className = 'overflow-hidden flex-grow';
+                const abstractSpan = document.createElement('span');
+                abstractSpan.className = 'text-sm leading-relaxed line-clamp-4 break-words';
+                abstractSpan.textContent = post.abstract;
+                abstractDiv.appendChild(abstractSpan);
+                body.appendChild(abstractDiv);
+
+                const footer = document.createElement('div');
+                footer.className = 'flex justify-between items-center mt-auto pt-2 w-full';
+                const authorLink = document.createElement('a');
+                authorLink.href = '/user/' + post.author;
+                authorLink.className = 'flex items-center gap-2 min-w-0';
+
+                const avatar = document.createElement('img');
+                avatar.alt = 'Profile';
+                avatar.src = post.author_picture || '';
+                avatar.className = 'w-8 h-8 rounded object-cover flex-shrink-0';
+                authorLink.appendChild(avatar);
+
+                const nameSpan = document.createElement('span');
+                nameSpan.className = 'font-medium text-sm truncate';
+                nameSpan.textContent = post.author;
+                authorLink.appendChild(nameSpan);
+
+                const dateSpan = document.createElement('span');
+                dateSpan.className = 'date text-sm flex-shrink-0';
+                dateSpan.textContent = new Date(post.timestamp * 1000).toLocaleDateString();
+
+                footer.appendChild(authorLink);
+                footer.appendChild(dateSpan);
+                body.appendChild(footer);
+                card.appendChild(body);
+
+                container.appendChild(card);
             }
         } catch (e) {
             console.error(e);
         }
     }
 
-    setInterval(refreshPosts, 10000);
+    document.addEventListener('DOMContentLoaded', renderPosts);
 </script>
 {% endblock body %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -52,15 +52,29 @@
     <br />
 </div>
 
+<script src="https://cdn.jsdelivr.net/npm/ethers@5.7.2/dist/ethers.umd.min.js"></script>
 <script>
+    const rpcUrl = "{{ rpc_url }}";
+    const postContractAddress = "{{ post_contract_address }}";
+    const postContractAbi = {{ post_contract_abi | tojson }};
+
     async function renderPosts() {
         const container = document.getElementById('posts-container');
         container.innerHTML = '';
         try {
-            const response = await fetch('/api/posts');
-            if (!response.ok) return;
-            const data = await response.json();
-            for (const post of data.posts) {
+            const provider = new ethers.providers.JsonRpcProvider(rpcUrl);
+            const contract = new ethers.Contract(postContractAddress, postContractAbi, provider);
+            const nextId = await contract.nextPostId();
+            for (let i = 0; i < nextId; i++) {
+                const onchain = await contract.posts(i);
+                if (!onchain.exists) continue;
+                let meta = {};
+                try {
+                    const metaRes = await fetch(onchain.contentHash);
+                    meta = await metaRes.json();
+                } catch (err) {
+                    console.error(err);
+                }
                 const card = document.createElement('div');
                 card.className = 'flex flex-col bg-base-200 rounded-box w-[20rem] h-[30rem] hover:scale-105 duration-150';
 
@@ -71,9 +85,9 @@
                 imgWrap.appendChild(img);
                 card.appendChild(imgWrap);
 
-                if (post.magnet) {
+                if (meta.magnet) {
                     try {
-                        const imgRes = await fetch(post.magnet);
+                        const imgRes = await fetch(meta.magnet);
                         const blob = await imgRes.blob();
                         img.src = URL.createObjectURL(blob);
                     } catch (err) {
@@ -86,43 +100,47 @@
 
                 const cat = document.createElement('h3');
                 cat.className = 'text-secondary font-medium text-sm line-clamp-1';
-                cat.textContent = post.category;
+                cat.textContent = meta.category || '';
                 body.appendChild(cat);
 
                 const link = document.createElement('a');
-                link.href = post.url;
+                link.href = meta.url || '#';
                 link.className = 'link link-hover text-xl font-bold line-clamp-2 leading-tight';
-                link.textContent = post.title;
+                link.textContent = meta.title || `Post ${i}`;
                 body.appendChild(link);
 
                 const abstractDiv = document.createElement('div');
                 abstractDiv.className = 'overflow-hidden flex-grow';
                 const abstractSpan = document.createElement('span');
                 abstractSpan.className = 'text-sm leading-relaxed line-clamp-4 break-words';
-                abstractSpan.textContent = post.abstract;
+                abstractSpan.textContent = meta.abstract || '';
                 abstractDiv.appendChild(abstractSpan);
                 body.appendChild(abstractDiv);
 
                 const footer = document.createElement('div');
                 footer.className = 'flex justify-between items-center mt-auto pt-2 w-full';
                 const authorLink = document.createElement('a');
-                authorLink.href = '/user/' + post.author;
+                authorLink.href = '/user/' + (meta.author || onchain.author);
                 authorLink.className = 'flex items-center gap-2 min-w-0';
 
                 const avatar = document.createElement('img');
                 avatar.alt = 'Profile';
-                avatar.src = post.author_picture || '';
+                avatar.src = meta.author_picture || '';
                 avatar.className = 'w-8 h-8 rounded object-cover flex-shrink-0';
                 authorLink.appendChild(avatar);
 
                 const nameSpan = document.createElement('span');
                 nameSpan.className = 'font-medium text-sm truncate';
-                nameSpan.textContent = post.author;
+                nameSpan.textContent = meta.author || onchain.author;
                 authorLink.appendChild(nameSpan);
 
                 const dateSpan = document.createElement('span');
                 dateSpan.className = 'date text-sm flex-shrink-0';
-                dateSpan.textContent = new Date(post.timestamp * 1000).toLocaleDateString();
+                if (meta.timestamp) {
+                    dateSpan.textContent = new Date(meta.timestamp * 1000).toLocaleDateString();
+                } else {
+                    dateSpan.textContent = '';
+                }
 
                 footer.appendChild(authorLink);
                 footer.appendChild(dateSpan);


### PR DESCRIPTION
## Summary
- add `/api/posts` endpoint returning posts with magnet URLs and author data
- restore category filters and expose raw category for client-side queries
- fetch posts and images on the client via magnet URLs so pages start empty until blockchain data loads

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aeaa3ea1f083278fb9dc48188bf6a7