### PR TITLE
Enable on-chain post publishing

### DIFF
--- a/app/routes/createPost.py
+++ b/app/routes/createPost.py
@@ -159,17 +159,18 @@ def createPost():
                         )
 
                 try:
-                    contract = Settings.BLOCKCHAIN_CONTRACTS["PostStorage"]
-                    cfg = BlockchainConfig(
-                        rpc_url=Settings.BLOCKCHAIN_RPC_URL,
-                        contract_address=contract["address"],
-                        abi=contract["abi"],
-                    )
-                    payload = (
-                        f"{postTitle}|{postTags}|{postAbstract}|{postContent}|{postCategory}|{bannerMagnet}"
-                    )
-                    content_hash = hashlib.sha256(payload.encode()).hexdigest()
-                    create_post(cfg, content_hash)
+                    if not request.form.get("onchainTx"):
+                        contract = Settings.BLOCKCHAIN_CONTRACTS["PostStorage"]
+                        cfg = BlockchainConfig(
+                            rpc_url=Settings.BLOCKCHAIN_RPC_URL,
+                            contract_address=contract["address"],
+                            abi=contract["abi"],
+                        )
+                        payload = (
+                            f"{postTitle}|{postTags}|{postAbstract}|{postContent}|{postCategory}|{bannerMagnet}"
+                        )
+                        content_hash = hashlib.sha256(payload.encode()).hexdigest()
+                        create_post(cfg, content_hash)
                 except Exception as e:
                     Log.error(f"Failed to store post on-chain: {e}")
 
@@ -186,6 +187,8 @@ def createPost():
             "createPost.html",
             form=form,
             categories=categories,
+            post_contract_address=Settings.BLOCKCHAIN_CONTRACTS["PostStorage"]["address"],
+            post_contract_abi=Settings.BLOCKCHAIN_CONTRACTS["PostStorage"]["abi"],
         )
     else:
         Log.error(f"{request.remote_addr} tried to create a new post without login")

--- a/app/static/js/bannerMagnet.js
+++ b/app/static/js/bannerMagnet.js
@@ -40,6 +40,6 @@
         e.preventDefault();
         const file = bannerInput.files[0];
         magnetField.value = await seedFile(file);
-        form.submit();
+        form.requestSubmit();
     });
 })();

--- a/app/static/js/createPost.js
+++ b/app/static/js/createPost.js
@@ -1,0 +1,46 @@
+// Handle on-chain post creation before form submission
+window.addEventListener('DOMContentLoaded', () => {
+    const form = document.querySelector('form');
+    if (!form) return;
+
+    let submitting = false;
+    form.addEventListener('submit', async (e) => {
+        if (submitting) return;
+
+        const bannerInput = form.querySelector('input[name="postBanner"]');
+        const magnetField = form.querySelector('input[name="postBannerMagnet"]');
+        if (bannerInput && bannerInput.files.length && magnetField && !magnetField.value) {
+            // Wait for bannerMagnet.js to generate the magnet and resubmit
+            return;
+        }
+        if (typeof window.ethereum === 'undefined' || typeof postContractAddress === 'undefined') {
+            submitting = true;
+            return;
+        }
+        e.preventDefault();
+        try {
+            await window.ethereum.request({ method: 'eth_requestAccounts' });
+            const title = form.postTitle.value.trim();
+            const tags = form.postTags.value.trim();
+            const abs = form.postAbstract.value.trim();
+            const content = form.postContent.value.trim();
+            const category = form.postCategory.value;
+            const magnet = magnetField ? magnetField.value.trim() : '';
+            const payload = `${title}|${tags}|${abs}|${content}|${category}|${magnet}`;
+            const encoder = new TextEncoder();
+            const hashBuffer = await crypto.subtle.digest('SHA-256', encoder.encode(payload));
+            const hashArray = Array.from(new Uint8Array(hashBuffer));
+            const contentHash = hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
+            const provider = new ethers.providers.Web3Provider(window.ethereum);
+            const signer = provider.getSigner();
+            const contract = new ethers.Contract(postContractAddress, postContractAbi, signer);
+            const tx = await contract.createPost(contentHash);
+            document.getElementById('onchainTx').value = tx.hash;
+            await tx.wait();
+        } catch (err) {
+            console.error('Failed to create post on-chain', err);
+        }
+        submitting = true;
+        form.requestSubmit();
+    });
+});

--- a/app/templates/createPost.html
+++ b/app/templates/createPost.html
@@ -8,6 +8,7 @@
 <div class="w-fit mx-auto mt-8">
     <form method="post" enctype="multipart/form-data">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+        <input type="hidden" name="onchainTx" id="onchainTx" />
 
         {{ form.postTitle(class_="input input-bordered w-full my-2",
         autocomplete="off",placeholder=translations.createPost.titlePlaceholder)
@@ -58,5 +59,11 @@
     </form>
     <script src="{{ url_for('static', filename='js/markdownEditor.js') }}"></script>
     <script src="{{ url_for('static', filename='js/bannerMagnet.js') }}"></script>
+    <script src="https://cdn.jsdelivr.net/npm/ethers@5.7.2/dist/ethers.umd.min.js"></script>
+    <script>
+        const postContractAddress = "{{ post_contract_address }}";
+        const postContractAbi = {{ post_contract_abi | tojson }};
+    </script>
+    <script src="{{ url_for('static', filename='js/createPost.js') }}"></script>
 </div>
 {% endblock body %}


### PR DESCRIPTION
## Summary
- allow create post page to submit to PostStorage contract before sending form
- avoid duplicate on-chain posts and expose contract ABI/address to template
- fix banner magnet flow to resubmit after magnet seeding

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aeb06894dc832799fa00deaa13f85f