### PR TITLE
Allow RPC connections in CSP

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -257,7 +257,8 @@ def afterRequest(response):
         "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://code.jquery.com https://cdn.tailwindcss.com; "
         "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdn.tailwindcss.com; "
         "img-src 'self' data: https: blob:; "
-        "font-src 'self' https://cdn.jsdelivr.net;"
+        "font-src 'self' https://cdn.jsdelivr.net; "
+        "connect-src 'self' https://mainnet.era.zksync.io;"
     )
     return response
 


### PR DESCRIPTION
## Summary
- permit outbound RPC calls by adding connect-src directive to CSP

## Testing
- `python -m py_compile app/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68aeb53ca354832792ce0e8bc5fabc96