### PR TITLE
Handle missing profile icons and magnet errors

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -254,7 +254,8 @@ def afterRequest(response):
     response = afterRequestLogger(response)
     response.headers["Content-Security-Policy"] = (
         "default-src 'self'; "
-        "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://code.jquery.com https://cdn.tailwindcss.com; "
+        "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://code.jquery.com https://cdn.tailwindcss.com blob:; "
+        "worker-src 'self' blob:; "
         "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdn.tailwindcss.com; "
         "img-src 'self' data: https: blob:; "
         "font-src 'self' https://cdn.jsdelivr.net; "

--- a/app/static/js/magnet.js
+++ b/app/static/js/magnet.js
@@ -14,13 +14,17 @@
         try {
             const res = await fetch(`/magnet/${id}`);
             const data = await res.json();
-            client.add(data.magnet, (torrent) => {
-                torrent.files[0].getBlob((err, blob) => {
-                    if (!err) {
-                        img.src = URL.createObjectURL(blob);
-                    }
+            if (data.magnet) {
+                client.add(data.magnet, (torrent) => {
+                    torrent.files[0].getBlob((err, blob) => {
+                        if (!err) {
+                            img.src = URL.createObjectURL(blob);
+                        }
+                    });
                 });
-            });
+            } else {
+                console.warn("No magnet URI returned for", id);
+            }
         } catch (e) {
             console.error("Failed to load magnet", id, e);
         }

--- a/app/utils/getProfilePicture.py
+++ b/app/utils/getProfilePicture.py
@@ -12,7 +12,8 @@ def getProfilePicture(userName):
         userName (str): The username of the user whose profile picture is to be retrieved.
 
     Returns:
-        str or None: The profile picture URL of the user, or None if not found.
+        str: The profile picture URL of the user. If no picture is stored in the
+        database, a DiceBear identicon URL is generated as a fallback.
     """
     Log.database(f"Connecting to '{Settings.DB_USERS_ROOT}' database")
 
@@ -27,10 +28,18 @@ def getProfilePicture(userName):
     )
     try:
         profilePicture = cursor.fetchone()[0]
-
         Log.info(f"Returning {userName}'s profile picture: {profilePicture}")
     except Exception:
         profilePicture = None
         Log.error(f"Failed to retrieve profile picture for user: {userName}")
+
+    # Fallback to DiceBear identicon service if no profile picture is set
+    if not profilePicture:
+        Log.info(
+            f"No profile picture found for {userName}, using DiceBear identicon service"
+        )
+        profilePicture = (
+            f"https://api.dicebear.com/7.x/identicon/svg?seed={userName}&radius=10"
+        )
 
     return profilePicture


### PR DESCRIPTION
## Summary
- Default to DiceBear identicon when a user profile picture is missing
- Skip WebTorrent client creation when no magnet URI is available
- Loosen CSP to allow blob workers for WebTorrent

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aeb67b91208327b758e768bf8241b6