### PR TITLE
Add retrieval and blacklisting for on-chain content

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -356,24 +356,9 @@ class Settings:
     {
       "anonymous": false,
       "inputs": [
-        {
-          "indexed": true,
-          "internalType": "uint256",
-          "name": "postId",
-          "type": "uint256"
-        },
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "author",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "internalType": "string",
-          "name": "contentHash",
-          "type": "string"
-        }
+        {"indexed": true, "internalType": "uint256", "name": "postId", "type": "uint256"},
+        {"indexed": true, "internalType": "address", "name": "author", "type": "address"},
+        {"indexed": false, "internalType": "string", "name": "contentHash", "type": "string"}
       ],
       "name": "PostCreated",
       "type": "event"
@@ -381,42 +366,34 @@ class Settings:
     {
       "anonymous": false,
       "inputs": [
-        {
-          "indexed": true,
-          "internalType": "uint256",
-          "name": "postId",
-          "type": "uint256"
-        }
+        {"indexed": true, "internalType": "uint256", "name": "postId", "type": "uint256"}
       ],
       "name": "PostDeleted",
       "type": "event"
     },
     {
+      "anonymous": false,
       "inputs": [
-        {
-          "internalType": "string",
-          "name": "contentHash",
-          "type": "string"
-        }
+        {"indexed": true, "internalType": "uint256", "name": "postId", "type": "uint256"},
+        {"indexed": false, "internalType": "bool", "name": "isBlacklisted", "type": "bool"}
+      ],
+      "name": "PostBlacklistUpdated",
+      "type": "event"
+    },
+    {
+      "inputs": [
+        {"internalType": "string", "name": "contentHash", "type": "string"}
       ],
       "name": "createPost",
       "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "postId",
-          "type": "uint256"
-        }
+        {"internalType": "uint256", "name": "postId", "type": "uint256"}
       ],
       "stateMutability": "nonpayable",
       "type": "function"
     },
     {
       "inputs": [
-        {
-          "internalType": "uint256",
-          "name": "postId",
-          "type": "uint256"
-        }
+        {"internalType": "uint256", "name": "postId", "type": "uint256"}
       ],
       "name": "deletePost",
       "outputs": [],
@@ -424,43 +401,55 @@ class Settings:
       "type": "function"
     },
     {
-      "inputs": [],
-      "name": "nextPostId",
+      "inputs": [
+        {"internalType": "uint256", "name": "postId", "type": "uint256"},
+        {"internalType": "bool", "name": "isBlacklisted", "type": "bool"}
+      ],
+      "name": "setBlacklist",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {"internalType": "uint256", "name": "postId", "type": "uint256"}
+      ],
+      "name": "getPost",
       "outputs": [
         {
-          "internalType": "uint256",
+          "components": [
+            {"internalType": "address", "name": "author", "type": "address"},
+            {"internalType": "string", "name": "contentHash", "type": "string"},
+            {"internalType": "bool", "name": "exists", "type": "bool"},
+            {"internalType": "bool", "name": "blacklisted", "type": "bool"}
+          ],
+          "internalType": "struct PostStorage.Post",
           "name": "",
-          "type": "uint256"
+          "type": "tuple"
         }
       ],
       "stateMutability": "view",
       "type": "function"
     },
     {
+      "inputs": [],
+      "name": "nextPostId",
+      "outputs": [
+        {"internalType": "uint256", "name": "", "type": "uint256"}
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
       "inputs": [
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
+        {"internalType": "uint256", "name": "", "type": "uint256"}
       ],
       "name": "posts",
       "outputs": [
-        {
-          "internalType": "address",
-          "name": "author",
-          "type": "address"
-        },
-        {
-          "internalType": "string",
-          "name": "contentHash",
-          "type": "string"
-        },
-        {
-          "internalType": "bool",
-          "name": "exists",
-          "type": "bool"
-        }
+        {"internalType": "address", "name": "author", "type": "address"},
+        {"internalType": "string", "name": "contentHash", "type": "string"},
+        {"internalType": "bool", "name": "exists", "type": "bool"},
+        {"internalType": "bool", "name": "blacklisted", "type": "bool"}
       ],
       "stateMutability": "view",
       "type": "function"
@@ -469,11 +458,7 @@ class Settings:
       "inputs": [],
       "name": "sysop",
       "outputs": [
-        {
-          "internalType": "address",
-          "name": "",
-          "type": "address"
-        }
+        {"internalType": "address", "name": "", "type": "address"}
       ],
       "stateMutability": "view",
       "type": "function"
@@ -493,30 +478,10 @@ class Settings:
     {
       "anonymous": false,
       "inputs": [
-        {
-          "indexed": true,
-          "internalType": "uint256",
-          "name": "commentId",
-          "type": "uint256"
-        },
-        {
-          "indexed": true,
-          "internalType": "uint256",
-          "name": "postId",
-          "type": "uint256"
-        },
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "author",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "internalType": "string",
-          "name": "content",
-          "type": "string"
-        }
+        {"indexed": true, "internalType": "uint256", "name": "commentId", "type": "uint256"},
+        {"indexed": true, "internalType": "uint256", "name": "postId", "type": "uint256"},
+        {"indexed": true, "internalType": "address", "name": "author", "type": "address"},
+        {"indexed": false, "internalType": "string", "name": "content", "type": "string"}
       ],
       "name": "CommentAdded",
       "type": "event"
@@ -524,76 +489,35 @@ class Settings:
     {
       "anonymous": false,
       "inputs": [
-        {
-          "indexed": true,
-          "internalType": "uint256",
-          "name": "commentId",
-          "type": "uint256"
-        }
+        {"indexed": true, "internalType": "uint256", "name": "commentId", "type": "uint256"}
       ],
       "name": "CommentDeleted",
       "type": "event"
     },
     {
+      "anonymous": false,
       "inputs": [
-        {
-          "internalType": "uint256",
-          "name": "postId",
-          "type": "uint256"
-        },
-        {
-          "internalType": "string",
-          "name": "content",
-          "type": "string"
-        }
+        {"indexed": true, "internalType": "uint256", "name": "commentId", "type": "uint256"},
+        {"indexed": false, "internalType": "bool", "name": "isBlacklisted", "type": "bool"}
+      ],
+      "name": "CommentBlacklistUpdated",
+      "type": "event"
+    },
+    {
+      "inputs": [
+        {"internalType": "uint256", "name": "postId", "type": "uint256"},
+        {"internalType": "string", "name": "content", "type": "string"}
       ],
       "name": "addComment",
       "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "commentId",
-          "type": "uint256"
-        }
+        {"internalType": "uint256", "name": "commentId", "type": "uint256"}
       ],
       "stateMutability": "nonpayable",
       "type": "function"
     },
     {
       "inputs": [
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "name": "comments",
-      "outputs": [
-        {
-          "internalType": "address",
-          "name": "author",
-          "type": "address"
-        },
-        {
-          "internalType": "uint256",
-          "name": "postId",
-          "type": "uint256"
-        },
-        {
-          "internalType": "string",
-          "name": "content",
-          "type": "string"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "uint256",
-          "name": "commentId",
-          "type": "uint256"
-        }
+        {"internalType": "uint256", "name": "commentId", "type": "uint256"}
       ],
       "name": "deleteComment",
       "outputs": [],
@@ -601,14 +525,57 @@ class Settings:
       "type": "function"
     },
     {
+      "inputs": [
+        {"internalType": "uint256", "name": "commentId", "type": "uint256"},
+        {"internalType": "bool", "name": "isBlacklisted", "type": "bool"}
+      ],
+      "name": "setBlacklist",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {"internalType": "uint256", "name": "commentId", "type": "uint256"}
+      ],
+      "name": "getComment",
+      "outputs": [
+        {
+          "components": [
+            {"internalType": "address", "name": "author", "type": "address"},
+            {"internalType": "uint256", "name": "postId", "type": "uint256"},
+            {"internalType": "string", "name": "content", "type": "string"},
+            {"internalType": "bool", "name": "exists", "type": "bool"},
+            {"internalType": "bool", "name": "blacklisted", "type": "bool"}
+          ],
+          "internalType": "struct CommentStorage.Comment",
+          "name": "",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
       "inputs": [],
       "name": "nextCommentId",
       "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
+        {"internalType": "uint256", "name": "", "type": "uint256"}
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {"internalType": "uint256", "name": "", "type": "uint256"}
+      ],
+      "name": "comments",
+      "outputs": [
+        {"internalType": "address", "name": "author", "type": "address"},
+        {"internalType": "uint256", "name": "postId", "type": "uint256"},
+        {"internalType": "string", "name": "content", "type": "string"},
+        {"internalType": "bool", "name": "exists", "type": "bool"},
+        {"internalType": "bool", "name": "blacklisted", "type": "bool"}
       ],
       "stateMutability": "view",
       "type": "function"
@@ -617,11 +584,7 @@ class Settings:
       "inputs": [],
       "name": "sysop",
       "outputs": [
-        {
-          "internalType": "address",
-          "name": "",
-          "type": "address"
-        }
+        {"internalType": "address", "name": "", "type": "address"}
       ],
       "stateMutability": "view",
       "type": "function"
@@ -766,72 +729,25 @@ class Settings:
     {
       "anonymous": false,
       "inputs": [
-        {
-          "indexed": true,
-          "internalType": "string",
-          "name": "imageId",
-          "type": "string"
-        },
-        {
-          "indexed": false,
-          "internalType": "string",
-          "name": "magnetURI",
-          "type": "string"
-        }
+        {"indexed": true, "internalType": "string", "name": "imageId", "type": "string"},
+        {"indexed": false, "internalType": "string", "name": "magnetURI", "type": "string"}
       ],
       "name": "ImageMagnetSet",
       "type": "event"
     },
     {
+      "anonymous": false,
       "inputs": [
-        {
-          "internalType": "string",
-          "name": "imageId",
-          "type": "string"
-        }
+        {"indexed": true, "internalType": "string", "name": "imageId", "type": "string"},
+        {"indexed": false, "internalType": "bool", "name": "isBlacklisted", "type": "bool"}
       ],
-      "name": "getImageMagnet",
-      "outputs": [
-        {
-          "internalType": "string",
-          "name": "",
-          "type": "string"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
+      "name": "ImageBlacklistUpdated",
+      "type": "event"
     },
     {
       "inputs": [
-        {
-          "internalType": "string",
-          "name": "",
-          "type": "string"
-        }
-      ],
-      "name": "imageMagnets",
-      "outputs": [
-        {
-          "internalType": "string",
-          "name": "",
-          "type": "string"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "string",
-          "name": "imageId",
-          "type": "string"
-        },
-        {
-          "internalType": "string",
-          "name": "magnetURI",
-          "type": "string"
-        }
+        {"internalType": "string", "name": "imageId", "type": "string"},
+        {"internalType": "string", "name": "magnetURI", "type": "string"}
       ],
       "name": "setImageMagnet",
       "outputs": [],
@@ -839,14 +755,65 @@ class Settings:
       "type": "function"
     },
     {
+      "inputs": [
+        {"internalType": "string", "name": "imageId", "type": "string"},
+        {"internalType": "bool", "name": "isBlacklisted", "type": "bool"}
+      ],
+      "name": "setBlacklist",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {"internalType": "string", "name": "imageId", "type": "string"}
+      ],
+      "name": "getImageMagnet",
+      "outputs": [
+        {"internalType": "string", "name": "", "type": "string"}
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {"internalType": "string", "name": "imageId", "type": "string"}
+      ],
+      "name": "getImage",
+      "outputs": [
+        {"internalType": "string", "name": "magnetURI", "type": "string"},
+        {"internalType": "bool", "name": "isBlacklisted", "type": "bool"}
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {"internalType": "string", "name": "", "type": "string"}
+      ],
+      "name": "imageMagnets",
+      "outputs": [
+        {"internalType": "string", "name": "", "type": "string"}
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {"internalType": "string", "name": "", "type": "string"}
+      ],
+      "name": "blacklisted",
+      "outputs": [
+        {"internalType": "bool", "name": "", "type": "bool"}
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
       "inputs": [],
       "name": "sysop",
       "outputs": [
-        {
-          "internalType": "address",
-          "name": "",
-          "type": "address"
-        }
+        {"internalType": "address", "name": "", "type": "address"}
       ],
       "stateMutability": "view",
       "type": "function"

--- a/contracts/CommentStorage.sol
+++ b/contracts/CommentStorage.sol
@@ -10,6 +10,8 @@ contract CommentStorage {
         address author;
         uint256 postId;
         string content;
+        bool exists;
+        bool blacklisted;
     }
 
     uint256 public nextCommentId;
@@ -17,6 +19,7 @@ contract CommentStorage {
 
     event CommentAdded(uint256 indexed commentId, uint256 indexed postId, address indexed author, string content);
     event CommentDeleted(uint256 indexed commentId);
+    event CommentBlacklistUpdated(uint256 indexed commentId, bool isBlacklisted);
 
     modifier onlySysop() {
         require(msg.sender == sysop, "only sysop");
@@ -29,15 +32,29 @@ contract CommentStorage {
 
     function addComment(uint256 postId, string calldata content) external returns (uint256 commentId) {
         commentId = nextCommentId++;
-        comments[commentId] = Comment(msg.sender, postId, content);
+        comments[commentId] = Comment(msg.sender, postId, content, true, false);
         emit CommentAdded(commentId, postId, msg.sender, content);
     }
 
     function deleteComment(uint256 commentId) external {
         Comment storage c = comments[commentId];
+        require(c.exists, "no comment");
         require(c.author == msg.sender || msg.sender == sysop, "not authorized");
         delete comments[commentId];
         emit CommentDeleted(commentId);
+    }
+
+    function setBlacklist(uint256 commentId, bool isBlacklisted) external onlySysop {
+        Comment storage c = comments[commentId];
+        require(c.exists, "no comment");
+        c.blacklisted = isBlacklisted;
+        emit CommentBlacklistUpdated(commentId, isBlacklisted);
+    }
+
+    function getComment(uint256 commentId) external view returns (Comment memory) {
+        Comment memory c = comments[commentId];
+        require(c.exists, "no comment");
+        return c;
     }
 }
 

--- a/contracts/ImageStorage.sol
+++ b/contracts/ImageStorage.sol
@@ -6,8 +6,10 @@ pragma solidity ^0.8.20;
 contract ImageStorage {
     address public sysop;
     mapping(string => string) public imageMagnets;
+    mapping(string => bool) public blacklisted;
 
     event ImageMagnetSet(string indexed imageId, string magnetURI);
+    event ImageBlacklistUpdated(string indexed imageId, bool isBlacklisted);
 
     modifier onlySysop() {
         require(msg.sender == sysop, "only sysop");
@@ -23,8 +25,17 @@ contract ImageStorage {
         emit ImageMagnetSet(imageId, magnetURI);
     }
 
+    function setBlacklist(string calldata imageId, bool isBlacklisted) external onlySysop {
+        blacklisted[imageId] = isBlacklisted;
+        emit ImageBlacklistUpdated(imageId, isBlacklisted);
+    }
+
     function getImageMagnet(string calldata imageId) external view returns (string memory) {
         return imageMagnets[imageId];
+    }
+
+    function getImage(string calldata imageId) external view returns (string memory magnetURI, bool isBlacklisted) {
+        return (imageMagnets[imageId], blacklisted[imageId]);
     }
 }
 

--- a/contracts/PostStorage.sol
+++ b/contracts/PostStorage.sol
@@ -10,6 +10,7 @@ contract PostStorage {
         address author;
         string contentHash;
         bool exists;
+        bool blacklisted;
     }
 
     uint256 public nextPostId;
@@ -17,6 +18,7 @@ contract PostStorage {
 
     event PostCreated(uint256 indexed postId, address indexed author, string contentHash);
     event PostDeleted(uint256 indexed postId);
+    event PostBlacklistUpdated(uint256 indexed postId, bool isBlacklisted);
 
     modifier onlySysop() {
         require(msg.sender == sysop, "only sysop");
@@ -29,7 +31,7 @@ contract PostStorage {
 
     function createPost(string calldata contentHash) external returns (uint256 postId) {
         postId = nextPostId++;
-        posts[postId] = Post(msg.sender, contentHash, true);
+        posts[postId] = Post(msg.sender, contentHash, true, false);
         emit PostCreated(postId, msg.sender, contentHash);
     }
 
@@ -39,6 +41,19 @@ contract PostStorage {
         require(msg.sender == p.author || msg.sender == sysop, "not authorized");
         delete posts[postId];
         emit PostDeleted(postId);
+    }
+
+    function setBlacklist(uint256 postId, bool isBlacklisted) external onlySysop {
+        Post storage p = posts[postId];
+        require(p.exists, "no post");
+        p.blacklisted = isBlacklisted;
+        emit PostBlacklistUpdated(postId, isBlacklisted);
+    }
+
+    function getPost(uint256 postId) external view returns (Post memory) {
+        Post memory p = posts[postId];
+        require(p.exists, "no post");
+        return p;
     }
 }
 


### PR DESCRIPTION
## Summary
- allow sysop to blacklist on-chain posts and expose getPost
- add comment retrieval and admin blacklist controls
- extend image storage with blacklist flag and retrieval

## Testing
- `python -m py_compile app/settings.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af0704e3608327b26bcbb90def4acf