### PR TITLE
Allow WebTorrent trackers in CSP

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -261,7 +261,7 @@ def afterRequest(response):
         "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdn.tailwindcss.com; "
         "img-src 'self' data: https: blob:; "
         "font-src 'self' https://cdn.jsdelivr.net; "
-        "connect-src 'self' https://mainnet.era.zksync.io;"
+        "connect-src 'self' https://mainnet.era.zksync.io wss://tracker.btorrent.xyz wss://tracker.openwebtorrent.com;"
     )
     return response
 


### PR DESCRIPTION
## Summary
- expand CSP connect-src to include WebTorrent trackers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68af1b77b5b48327af8f0217c73a7d3f