### PR TITLE
Modernize front page post tiles

### DIFF
--- a/app/static/css/postTiles.css
+++ b/app/static/css/postTiles.css
@@ -1,16 +1,51 @@
 .post-tile {
     position: relative;
-    width: 20rem;
+    width: 100%;
     height: 20rem;
-    background-size: cover;
-    background-position: center;
+    overflow: hidden;
     border-radius: 0.5rem;
+    cursor: pointer;
     transition: transform 0.6s;
     transform-style: preserve-3d;
-    cursor: pointer;
     display: block;
 }
 
 .post-tile:hover {
     transform: rotateY(180deg);
+}
+
+.post-tile img {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    backface-visibility: hidden;
+}
+
+.post-tile .tile-overlay {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    padding: 1rem;
+    background: linear-gradient(to top, rgba(0, 0, 0, 0.7), transparent);
+    color: #fff;
+    backface-visibility: hidden;
+}
+
+.post-tile .tile-category {
+    font-size: 0.875rem;
+    margin-bottom: 0.25rem;
+}
+
+.post-tile .tile-title {
+    font-size: 1.25rem;
+    font-weight: 700;
+    line-height: 1.2;
 }

--- a/app/templates/components/postCardMacro.html
+++ b/app/templates/components/postCardMacro.html
@@ -1,44 +1,16 @@
 {% macro postCard(post, authorProfilePicture) %}
-<div
-    class="flex flex-col bg-base-200 rounded-box w-[20rem] h-[30rem] hover:scale-105 duration-150"
+<a
+    href="{{ url_for('post.post', slug=getSlugFromPostTitle(post[1]), urlID=post[10]) }}"
+    class="post-tile"
 >
-    <div class="overflow-hidden flex-shrink-0">
-        <img
-            data-magnet-id="{{ post[0] }}.png"
-            class="h-48 w-full group-hover:scale-110 transition duration-150 object-cover rounded-t-md select-none"
-        />
+    <img
+        data-magnet-id="{{ post[0] }}.png"
+        alt="{{ post[1] }}"
+        class="select-none"
+    />
+    <div class="tile-overlay">
+        <span class="tile-category">{{ post[9] }}</span>
+        <h2 class="tile-title">{{ post[1] }}</h2>
     </div>
-    <div class="flex flex-col gap-4 p-6 flex-grow">
-        <h3 class="text-secondary font-medium text-sm line-clamp-1">
-            {{ post[9] }}
-        </h3>
-
-        <a
-            href="{{ url_for('post.post', slug=getSlugFromPostTitle(post[1]), urlID=post[10]) }}"
-            class="link link-hover text-xl font-bold line-clamp-2 leading-tight"
-            >{{ post[1] }}</a
-        >
-
-        <div class="overflow-hidden flex-grow">
-            <span class="text-sm leading-relaxed line-clamp-4 break-words">
-                {{ post[11] }}
-            </span>
-        </div>
-
-        <div class="flex justify-between items-center mt-auto pt-2 w-full">
-            <a
-                href="/user/{{ post[5] }}"
-                class="flex items-center gap-2 min-w-0"
-            >
-                <img
-                    alt="Profile"
-                    src="{{ authorProfilePicture }}"
-                    class="w-8 h-8 rounded object-cover flex-shrink-0"
-                />
-                <span class="font-medium text-sm truncate">{{ post[5] }}</span>
-            </a>
-            <span class="date text-sm flex-shrink-0">{{ post[7] }}</span>
-        </div>
-    </div>
-</div>
+</a>
 {% endmacro %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -37,7 +37,7 @@
 
 <div
     id="posts-container"
-    class="flex item-center justify-center flex-wrap gap-x-4 gap-y-6 mx-auto w-11/12 md:w-11/12 lg:w-10/12 2xl:w-9/12 mt-6"
+    class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mx-auto w-11/12 md:w-11/12 lg:w-10/12 2xl:w-9/12 mt-6"
 >
     {% include 'components/postCards.html' %}
 </div>


### PR DESCRIPTION
## Summary
- Display posts in a responsive grid on the front page
- Style post tiles with banner images and flip-on-hover effect

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af1b95947c8327a30898e4fdebe85b