### PR TITLE
feat: seed torrents in background

### DIFF
--- a/app/static/js/torrentSeeder.js
+++ b/app/static/js/torrentSeeder.js
@@ -1,0 +1,23 @@
+(async () => {
+    if (typeof WebTorrent === 'undefined') {
+        await new Promise((resolve) => {
+            const script = document.createElement('script');
+            script.src = 'https://cdn.jsdelivr.net/npm/webtorrent@latest/webtorrent.min.js';
+            script.onload = resolve;
+            document.head.appendChild(script);
+        });
+    }
+
+    const client = new WebTorrent();
+    window.torrentClient = client; // keep reference
+    const links = document.querySelectorAll('a[href$=".torrent"]');
+    links.forEach((link) => {
+        try {
+            client.add(link.href, (torrent) => {
+                console.log('Seeding', torrent.infoHash);
+            });
+        } catch (err) {
+            console.error('Error adding torrent', link.href, err);
+        }
+    });
+})();

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -90,6 +90,7 @@
             const imageContractAbi = {{ image_contract_abi | tojson }};
         </script>
         <script src="{{ url_for('static', filename='js/magnet.js') }}"></script>
+        <script src="{{ url_for('static', filename='js/torrentSeeder.js') }}"></script>
         <link
             rel="stylesheet"
             href="{{ url_for('static', filename='css/recaptcha.css') }}"


### PR DESCRIPTION
## Summary
- load WebTorrent client and seed any `.torrent` links found on the page
- include torrent seeding script in site layout so seeding runs in the background

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af1f231dd88327bddf27aa5d190eee