### PR TITLE
Simplify image posts and auto-seed torrents

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -3,6 +3,7 @@ This file contains the main function
 """
 
 from datetime import timedelta
+import os
 
 from flask import Flask
 from flask_wtf.csrf import (
@@ -131,6 +132,7 @@ from utils.generateUrlIdFromPost import getSlugFromPostTitle
 from utils.log import Log
 from utils.terminalASCII import terminalASCII
 from utils.time import currentTimeStamp
+from utils.torrent import ensure_seeding
 
 startTime = currentTimeStamp()
 
@@ -155,6 +157,9 @@ app.config["SESSION_PERMANENT"] = Settings.SESSION_PERMANENT
 
 
 csrf = CSRFProtect(app)
+
+images_dir = os.path.join(Settings.APP_ROOT_PATH, "images")
+ensure_seeding(images_dir)
 
 
 app.context_processor(isLogin)

--- a/app/routes/createPost.py
+++ b/app/routes/createPost.py
@@ -1,121 +1,34 @@
-import hashlib
 import os
 
-from flask import Blueprint, redirect, render_template, request, session, flash
+from flask import Blueprint, jsonify, render_template, request
+from werkzeug.utils import secure_filename
+
 from settings import Settings
-from utils.flashMessage import flashMessage
-from utils.forms.CreatePostForm import CreatePostForm
-from utils.log import Log
-from utils.categories import get_categories, DEFAULT_CATEGORIES
-from blockchain import (
-    BlockchainConfig,
-    set_image_magnet,
-    create_post,
-    get_next_post_id,
-)
-from utils.torrent import seed_file
+from utils.torrent import seed_file, ensure_seeding
 
 createPostBlueprint = Blueprint("createPost", __name__)
 
 
 @createPostBlueprint.route("/createpost", methods=["GET", "POST"])
 def createPost():
-    """
-    This function creates a new post for the user.
+    """Handle image uploads, seed them as torrents and return magnet URIs."""
+    if request.method == "POST":
+        image = request.files.get("postBanner")
+        if not image or image.filename == "":
+            return jsonify({"error": "no image supplied"}), 400
 
-    Args:
-        request (Request): The request object from the user.
+        images_dir = os.path.join(Settings.APP_ROOT_PATH, "images")
+        os.makedirs(images_dir, exist_ok=True)
+        filename = secure_filename(image.filename)
+        image_path = os.path.join(images_dir, filename)
+        image.save(image_path)
 
-    Returns:
-        Response: The response object with the HTML template for the create post page.
+        magnet = seed_file(image_path)
+        ensure_seeding(images_dir)
+        return jsonify({"magnet": magnet})
 
-    Raises:
-        401: If the user is not authenticated.
-    """
-
-    if "userName" in session:
-        categories = get_categories()
-        form = CreatePostForm(request.form)
-        form.postCategory.choices = [(c, c) for c in categories]
-
-        if request.method == "POST":
-            postTitle = request.form["postTitle"]
-            postTags = request.form["postTags"]
-            postAbstract = request.form["postAbstract"]
-            postContent = request.form["postContent"]
-            postBannerFile = request.files["postBanner"]
-            bannerMagnet = request.form.get("postBannerMagnet", "")
-            selectedCategory = request.form.get("postCategory", "").strip()
-            newCategory = request.form.get("newCategory", "").strip()
-
-            category_candidate = newCategory if newCategory else selectedCategory
-
-            if not category_candidate:
-                flash("Category is required.", "error")
-                return redirect("/createpost")
-
-            postCategory = category_candidate
-
-            if postContent == "" or postAbstract == "":
-                flashMessage(
-                    page="createPost",
-                    message="empty",
-                    category="error",
-                    language=session["language"],
-                )
-                Log.error(
-                    f'User: "{session["userName"]}" tried to create a post with empty content',
-                )
-            else:
-                try:
-                    contract = Settings.BLOCKCHAIN_CONTRACTS["PostStorage"]
-                    cfg = BlockchainConfig(
-                        rpc_url=Settings.BLOCKCHAIN_RPC_URL,
-                        contract_address=contract["address"],
-                        abi=contract["abi"],
-                    )
-                    post_id = get_next_post_id(cfg)
-                    payload = (
-                        f"{postTitle}|{postTags}|{postAbstract}|{postContent}|{postCategory}|{bannerMagnet}"
-                    )
-                    create_post(cfg, payload)
-                    if postBannerFile:
-                        images_dir = os.path.join(Settings.APP_ROOT_PATH, "images")
-                        os.makedirs(images_dir, exist_ok=True)
-                        image_path = os.path.join(images_dir, f"{post_id}.png")
-                        postBannerFile.save(image_path)
-                        bannerMagnet = seed_file(image_path)
-                        contract_img = Settings.BLOCKCHAIN_CONTRACTS["ImageStorage"]
-                        cfg_img = BlockchainConfig(
-                            rpc_url=Settings.BLOCKCHAIN_RPC_URL,
-                            contract_address=contract_img["address"],
-                            abi=contract_img["abi"],
-                        )
-                        set_image_magnet(cfg_img, f"{post_id}.png", bannerMagnet)
-                except Exception as e:
-                    Log.error(f"Failed to store post on-chain: {e}")
-
-                flashMessage(
-                    page="createPost",
-                    message="success",
-                    category="success",
-                    language=session["language"],
-                )
-                return redirect("/")
-
-        return render_template(
-            "createPost.html",
-            form=form,
-            categories=categories,
-            post_contract_address=Settings.BLOCKCHAIN_CONTRACTS["PostStorage"]["address"],
-            post_contract_abi=Settings.BLOCKCHAIN_CONTRACTS["PostStorage"]["abi"],
-        )
-    else:
-        Log.error(f"{request.remote_addr} tried to create a new post without login")
-        flashMessage(
-            page="createPost",
-            message="login",
-            category="error",
-            language=session["language"],
-        )
-        return redirect("/login?redirect=/createpost")
+    return render_template(
+        "createPost.html",
+        post_contract_address=Settings.BLOCKCHAIN_CONTRACTS["PostStorage"]["address"],
+        post_contract_abi=Settings.BLOCKCHAIN_CONTRACTS["PostStorage"]["abi"],
+    )

--- a/app/static/js/createPost.js
+++ b/app/static/js/createPost.js
@@ -1,46 +1,35 @@
-// Handle on-chain post creation before form submission
 window.addEventListener('DOMContentLoaded', () => {
     const form = document.querySelector('form');
     if (!form) return;
 
-    let submitting = false;
     form.addEventListener('submit', async (e) => {
-        if (submitting) return;
-
-        const bannerInput = form.querySelector('input[name="postBanner"]');
-        const magnetField = form.querySelector('input[name="postBannerMagnet"]');
-        if (bannerInput && bannerInput.files.length && magnetField && !magnetField.value) {
-            // Wait for bannerMagnet.js to generate the magnet and resubmit
-            return;
-        }
-        if (typeof window.ethereum === 'undefined' || typeof postContractAddress === 'undefined') {
-            submitting = true;
-            return;
-        }
         e.preventDefault();
+        const bannerInput = form.querySelector('input[name="postBanner"]');
+        if (!bannerInput || !bannerInput.files.length) return;
+        const data = new FormData();
+        data.append('postBanner', bannerInput.files[0]);
+        const csrf = form.querySelector('input[name="csrf_token"]');
+        if (csrf) data.append('csrf_token', csrf.value);
+
+        let magnet = '';
+        try {
+            const res = await fetch('/createpost', { method: 'POST', body: data });
+            const json = await res.json();
+            magnet = json.magnet;
+        } catch (err) {
+            console.error('Failed to upload image', err);
+            return;
+        }
+
+        if (typeof window.ethereum === 'undefined') return;
         try {
             await window.ethereum.request({ method: 'eth_requestAccounts' });
-            const title = form.postTitle.value.trim();
-            const tags = form.postTags.value.trim();
-            const abs = form.postAbstract.value.trim();
-            const content = form.postContent.value.trim();
-            const category = form.postCategory.value;
-            const magnet = magnetField ? magnetField.value.trim() : '';
-            const payload = `${title}|${tags}|${abs}|${content}|${category}|${magnet}`;
-            const encoder = new TextEncoder();
-            const hashBuffer = await crypto.subtle.digest('SHA-256', encoder.encode(payload));
-            const hashArray = Array.from(new Uint8Array(hashBuffer));
-            const contentHash = hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
             const provider = new ethers.providers.Web3Provider(window.ethereum);
             const signer = provider.getSigner();
             const contract = new ethers.Contract(postContractAddress, postContractAbi, signer);
-            const tx = await contract.createPost(contentHash);
-            document.getElementById('onchainTx').value = tx.hash;
-            await tx.wait();
+            await contract.createPost(magnet);
         } catch (err) {
-            console.error('Failed to create post on-chain', err);
+            console.error('Failed to interact with contract', err);
         }
-        submitting = true;
-        form.requestSubmit();
     });
 });

--- a/app/templates/createPost.html
+++ b/app/templates/createPost.html
@@ -1,64 +1,19 @@
-{% extends 'layout.html' %} {% block head %}
+{% extends 'layout.html' %}
+{% block head %}
 <title>{{ translations.createPost.title }}</title>
-<link
-    rel="stylesheet"
-    href="{{ url_for('static', filename='css/markdownEditor.css') }}"
-/>
-{% endblock head %} {% block body %}
+{% endblock head %}
+{% block body %}
 <div class="w-fit mx-auto mt-8">
     <form method="post" enctype="multipart/form-data">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-        <input type="hidden" name="onchainTx" id="onchainTx" />
-
-        {{ form.postTitle(class_="input input-bordered w-full my-2",
-        autocomplete="off",placeholder=translations.createPost.titlePlaceholder)
-        }} {{ form.postTags(class_="input input-bordered w-full my-2",
-        autocomplete="off",placeholder=translations.createPost.tags) }} {{
-        form.postAbstract(class_="textarea textarea-bordered w-full my-2",
-        autocomplete="off",placeholder=translations.createPost.abstractPlaceholder)
-        }}
-        <p class="text-xs text-center w-fit mx-auto mb-2">
-            {{ translations.createPost.separate }}
-        </p>
-
         <div class="w-72 mx-auto text-center mb-4">
-            <label class="block mt-2 mb-1"
-                >{{ translations.createPost.banner }}</label
-            >
-            {{ form.postBanner(class_="file-input file-input-bordered w-full",
-            placeholder=translations.createPost.bannerPlaceholder) }}
+            <label class="block mt-2 mb-1">{{ translations.createPost.banner }}</label>
+            <input type="file" name="postBanner" class="file-input file-input-bordered w-full" />
         </div>
-
-        <div class="mx-auto w-fit">
-            <label class="block my-1 text-center"
-                >{{ translations.createPost.category }}</label
-            >
-            <select
-                class="select select-bordered w-72"
-                id="postCategory"
-                name="postCategory"
-            >
-                {% for cat in categories %}
-                {% set key = cat|lower %}
-                <option value="{{ cat }}">{{
-                    translations.categories[key] if key in translations.categories else cat
-                }}</option>
-                {% endfor %}
-            </select>
-            {{ form.newCategory(class_="input input-bordered w-72 mt-2", autocomplete="off", placeholder="New Category") }}
-        </div>
-
-        <div>
-            {{ form.postContent(class_="textarea textarea-bordered w-full h-96",
-            id_="markdown-editor", autocomplete="off") }}
-        </div>
-
         <button type="submit" class="btn btn-neutral btn-block mt-4">
             {{ translations.createPost.post }}
         </button>
     </form>
-    <script src="{{ url_for('static', filename='js/markdownEditor.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/bannerMagnet.js') }}"></script>
     <script src="https://cdn.jsdelivr.net/npm/ethers@5.7.2/dist/ethers.umd.min.js"></script>
     <script>
         const postContractAddress = "{{ post_contract_address }}";

--- a/app/utils/torrent.py
+++ b/app/utils/torrent.py
@@ -21,3 +21,18 @@ def seed_file(file_path: str) -> str:
     ti = lt.torrent_info(torrent_path)
     _session.add_torrent({"ti": ti, "save_path": base_path})
     return lt.make_magnet_uri(ti)
+
+
+def ensure_seeding(directory: str) -> None:
+    """Seed any ``.torrent`` files found in ``directory``."""
+    if not os.path.isdir(directory):
+        return
+    for name in os.listdir(directory):
+        if not name.endswith(".torrent"):
+            continue
+        torrent_path = os.path.join(directory, name)
+        try:
+            ti = lt.torrent_info(torrent_path)
+            _session.add_torrent({"ti": ti, "save_path": directory})
+        except Exception:
+            continue


### PR DESCRIPTION
## Summary
- Refactor createPost to accept only image uploads, seed them as torrents, and return magnet URIs
- Streamline createPost page and JavaScript to upload images then call smart contract via ABI and address
- Add utility to seed existing .torrent files and ensure seeding at startup

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af2331a2b083279efbafff228ccc6e