### PR TITLE
Expose blockchain config on window for magnet loader

### DIFF
--- a/app/templates/category.html
+++ b/app/templates/category.html
@@ -35,9 +35,12 @@
 
 <script src="https://cdn.jsdelivr.net/npm/ethers@5.7.2/dist/ethers.umd.min.js"></script>
 <script>
-    const rpcUrl = "{{ rpc_url }}";
-    const postContractAddress = "{{ post_contract_address }}";
-    const postContractAbi = {{ post_contract_abi | tojson }};
+    window.rpcUrl = "{{ rpc_url }}";
+    window.postContractAddress = "{{ post_contract_address }}";
+    window.postContractAbi = {{ post_contract_abi | tojson }};
+    const rpcUrl = window.rpcUrl;
+    const postContractAddress = window.postContractAddress;
+    const postContractAbi = window.postContractAbi;
     const targetCategory = "{{ raw_category|lower }}";
 
     async function renderCategoryPosts() {

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -85,9 +85,9 @@
         <script src="{{ url_for('static', filename='js/readerControls.js') }}"></script>
         <script src="{{ url_for('static', filename='js/progress.js') }}"></script>
         <script>
-            const rpcUrl = "{{ rpc_url }}";
-            const postContractAddress = "{{ post_contract_address }}";
-            const postContractAbi = {{ post_contract_abi | tojson }};
+            window.rpcUrl = "{{ rpc_url }}";
+            window.postContractAddress = "{{ post_contract_address }}";
+            window.postContractAbi = {{ post_contract_abi | tojson }};
         </script>
         <script src="{{ url_for('static', filename='js/magnet.js') }}"></script>
         <script src="{{ url_for('static', filename='js/torrentSeeder.js') }}"></script>


### PR DESCRIPTION
## Summary
- make `rpcUrl`, `postContractAddress`, and `postContractAbi` available on `window`
- update category page to use window-exposed blockchain config

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af373841c88327b70c0875d5574270