### PR TITLE
fix: default contract abi when undefined

### DIFF
--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -87,7 +87,7 @@
         <script>
             window.rpcUrl = "{{ rpc_url }}";
             window.postContractAddress = "{{ post_contract_address }}";
-            window.postContractAbi = {{ post_contract_abi | tojson }};
+            window.postContractAbi = {{ post_contract_abi | default([], true) | tojson }};
         </script>
         <script src="{{ url_for('static', filename='js/magnet.js') }}"></script>
         <script src="{{ url_for('static', filename='js/torrentSeeder.js') }}"></script>


### PR DESCRIPTION
## Summary
- prevent JSON serialization error when contract ABI is absent by defaulting to empty list in layout

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af3e4b1ea4832786679535578c4c26