### PR TITLE
feat: display posts in overlay

### DIFF
--- a/app/static/css/overlay.css
+++ b/app/static/css/overlay.css
@@ -1,0 +1,48 @@
+#post-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
+    display: none;
+    justify-content: center;
+    align-items: flex-end;
+    z-index: 1000;
+}
+
+#post-overlay.show {
+    display: flex;
+}
+
+#post-overlay .overlay-content {
+    background: var(--b1);
+    border: 6px solid var(--bc);
+    width: 90%;
+    max-width: 900px;
+    height: 90%;
+    transform: translateY(100%);
+    transition: transform 0.3s ease-out;
+    border-radius: 0.5rem 0.5rem 0 0;
+    position: relative;
+    overflow: hidden;
+}
+
+#post-overlay.show .overlay-content {
+    transform: translateY(0);
+}
+
+#post-overlay .overlay-close {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    background: none;
+    border: none;
+    font-size: 2rem;
+    color: #ef4444;
+    cursor: pointer;
+    line-height: 1;
+}
+
+#post-overlay iframe {
+    width: 100%;
+    height: 100%;
+    border: 0;
+}

--- a/app/static/js/postOverlay.js
+++ b/app/static/js/postOverlay.js
@@ -1,0 +1,35 @@
+(function () {
+    const overlay = document.getElementById('post-overlay');
+    const iframe = document.getElementById('post-iframe');
+    const closeBtn = overlay.querySelector('.overlay-close');
+
+    function openOverlay(url) {
+        iframe.src = url;
+        overlay.classList.remove('hidden');
+        requestAnimationFrame(() => overlay.classList.add('show'));
+    }
+
+    function closeOverlay() {
+        overlay.classList.remove('show');
+        iframe.src = '';
+        setTimeout(() => overlay.classList.add('hidden'), 300);
+    }
+
+    document.addEventListener('click', function (e) {
+        const link = e.target.closest('a');
+        if (!link || !link.href) return;
+        const url = new URL(link.href, window.location.origin);
+        if (url.pathname.startsWith('/post/')) {
+            e.preventDefault();
+            openOverlay(url.href);
+        }
+    });
+
+    overlay.addEventListener('click', function (e) {
+        if (e.target === overlay) {
+            closeOverlay();
+        }
+    });
+
+    closeBtn.addEventListener('click', closeOverlay);
+})();

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -38,6 +38,11 @@
             href="{{ url_for('static', filename='css/markdown.css') }}"
         />
 
+        <link
+            rel="stylesheet"
+            href="{{ url_for('static', filename='css/overlay.css') }}"
+        />
+
         <meta property="og:type" content="website" />
         <meta property="og:title" content="flaskBlog" />
         <meta
@@ -70,6 +75,13 @@
         'components/navbar.html'%} {% from "components/flash.html" import flash
         %} {{ flash() }} {% block body %} {% endblock body %}
 
+        <div id="post-overlay" class="hidden">
+            <div class="overlay-content">
+                <button class="overlay-close" aria-label="Close">&times;</button>
+                <iframe id="post-iframe" src=""></iframe>
+            </div>
+        </div>
+
         <script
             src="https://code.jquery.com/jquery-3.4.1.slim.min.js"
             integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n"
@@ -91,6 +103,7 @@
         </script>
         <script src="{{ url_for('static', filename='js/magnet.js') }}"></script>
         <script src="{{ url_for('static', filename='js/torrentSeeder.js') }}"></script>
+        <script src="{{ url_for('static', filename='js/postOverlay.js') }}"></script>
         {% block scripts %}{% endblock scripts %}
         <link
             rel="stylesheet"


### PR DESCRIPTION
## Summary
- open posts in a sliding overlay instead of navigating to a new page
- add overlay styling and JavaScript to handle iframe, close button, and click-away behavior

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af43b9821c8327a288770dcc649275