### PR TITLE
Load posts from blockchain instead of local database

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -52,6 +52,9 @@ from routes.dashboard import (
 from routes.editPost import (
     editPostBlueprint,
 )
+from routes.createPost import (
+    createPostBlueprint,
+)
 from routes.index import (
     indexBlueprint,
 )
@@ -278,6 +281,7 @@ app.register_blueprint(editPostBlueprint)
 app.register_blueprint(dashboardBlueprint)
 app.register_blueprint(searchBarBlueprint)
 app.register_blueprint(adminPanelBlueprint)
+app.register_blueprint(createPostBlueprint)
 app.register_blueprint(verifyUserBlueprint)
 app.register_blueprint(setLanguageBlueprint)
 app.register_blueprint(setThemeBlueprint)

--- a/app/routes/createPost.py
+++ b/app/routes/createPost.py
@@ -1,0 +1,55 @@
+import os
+
+from flask import Blueprint, jsonify, render_template, request, session, redirect
+from werkzeug.utils import secure_filename
+
+from settings import Settings
+from utils.flashMessage import flashMessage
+from utils.forms.CreatePostForm import CreatePostForm
+from utils.log import Log
+from utils.categories import get_categories
+from utils.torrent import seed_file, ensure_seeding
+
+createPostBlueprint = Blueprint("createPost", __name__)
+
+
+@createPostBlueprint.route("/createpost", methods=["GET", "POST"])
+def createPost():
+    """Seed uploaded banners and render the post creation page."""
+    if request.method == "POST":
+        image = request.files.get("postBanner")
+        if not image or image.filename == "":
+            return jsonify({"error": "no image supplied"}), 400
+
+        images_dir = os.path.join(Settings.APP_ROOT_PATH, "images")
+        os.makedirs(images_dir, exist_ok=True)
+        filename = secure_filename(image.filename)
+        image_path = os.path.join(images_dir, filename)
+        image.save(image_path)
+
+        magnet = seed_file(image_path)
+        ensure_seeding(images_dir)
+        return jsonify({"magnet": magnet})
+
+    if "userName" not in session:
+        Log.error(f"{request.remote_addr} tried to create a new post without login")
+        flashMessage(
+            page="createPost",
+            message="login",
+            category="error",
+            language=session.get("language", "en"),
+        )
+        return redirect("/login?redirect=/createpost")
+
+    categories = get_categories()
+    form = CreatePostForm()
+    form.postCategory.choices = [(c, c) for c in categories]
+    post_contract = Settings.BLOCKCHAIN_CONTRACTS["PostStorage"]
+    return render_template(
+        "createPost.html",
+        form=form,
+        categories=categories,
+        post_contract_address=post_contract["address"],
+        post_contract_abi=post_contract["abi"],
+        rpc_url=Settings.BLOCKCHAIN_RPC_URL,
+    )

--- a/app/templates/components/navbar.html
+++ b/app/templates/components/navbar.html
@@ -36,6 +36,12 @@
             </div>
         </a>
 
+        <a href="/createpost" class="text-center">
+            <button class="hover:text-rose-500 duration-150">
+                <i class="ti ti-pencil-plus text-2xl"></i>
+            </button>
+        </a>
+
         <a
             href="/logout"
             title="logout"

--- a/app/templates/post.html
+++ b/app/templates/post.html
@@ -19,11 +19,11 @@
     <img data-magnet-id="{{ id }}.png" class="mx-auto rounded-md shadow-md select-none" />
     <h1 class="text-2xl md:text-3xl mt-3 text-rose-500 w-full text-center font-bold">{{ title }}</h1>
     <div class="flex items-center justify-center gap-2 my-4 select-none opacity-75">
-        <p class="text-sm font-medium"><span id="reading-time"></span> {{ translations.post.minRead }}</p>
+        <p class="text-sm font-medium"><span id="reading-time">{{ reading_time }}</span> {{ translations.post.minRead }}</p>
     </div>
     <div class="text-center font-sm max-w-full">{{ abstract }}</div>
     <div class="divider"></div>
-    <div id="post-content" class="markdown-content"></div>
+    <div id="post-content" class="markdown-content">{{ render_markdown(content) | safe }}</div>
     <div class="select-none mt-4">
         <div class="flex w-full justify-between my-1">
             <div class="flex items-center">
@@ -43,5 +43,4 @@
     <script>
         const postUrlID = {{ id }};
     </script>
-    <script src="{{ url_for('static', filename='js/postContent.js') }}"></script>
 {% endblock body %}


### PR DESCRIPTION
## Summary
- Restore /createpost route to seed banners and render post form with blockchain config
- Re-add Create Post button in navbar for logged-in users

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af44db29108327b796cff621709001