### PR TITLE
Load images via WebTorrent without local fallback

### DIFF
--- a/app/static/js/loadPosts.js
+++ b/app/static/js/loadPosts.js
@@ -24,6 +24,7 @@
             link.className = 'post-tile';
             const img = document.createElement('img');
             img.dataset.magnetId = `${id}.png`;
+            img.src = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
             img.alt = title;
             img.className = 'select-none';
             link.appendChild(img);

--- a/app/templates/category.html
+++ b/app/templates/category.html
@@ -68,18 +68,10 @@
                 imgWrap.className = 'overflow-hidden flex-shrink-0';
                 const img = document.createElement('img');
                 img.className = 'h-48 w-full group-hover:scale-110 transition duration-150 object-cover rounded-t-md select-none';
+                img.dataset.magnetId = `${i}.png`;
+                img.src = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
                 imgWrap.appendChild(img);
                 card.appendChild(imgWrap);
-
-                if (meta.magnet) {
-                    try {
-                        const imgRes = await fetch(meta.magnet);
-                        const blob = await imgRes.blob();
-                        img.src = URL.createObjectURL(blob);
-                    } catch (err) {
-                        console.error(err);
-                    }
-                }
 
                 const body = document.createElement('div');
                 body.className = 'flex flex-col gap-4 p-6 flex-grow';
@@ -134,6 +126,9 @@
                 card.appendChild(body);
 
                 container.appendChild(card);
+            }
+            if (typeof window.loadMagnets === 'function') {
+                window.loadMagnets();
             }
         } catch (e) {
             console.error(e);

--- a/app/templates/components/navbar.html
+++ b/app/templates/components/navbar.html
@@ -4,6 +4,7 @@
     <a href="/" class="duration-150">
         <img
             data-magnet-id="Icon180.ico"
+            src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw=="
             class="rounded w-14 hover:scale-110 duration-150 shadow"
         />
     </a>

--- a/app/templates/components/postCardMacro.html
+++ b/app/templates/components/postCardMacro.html
@@ -5,6 +5,7 @@
 >
     <img
         data-magnet-id="{{ post[0] }}.png"
+        src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw=="
         alt="{{ post[1] }}"
         class="select-none"
     />

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -14,6 +14,7 @@
 >
     <img
         data-magnet-id="{{ post[0] }}.png"
+        src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw=="
         class="w-96 rounded mx-auto"
     />
 

--- a/app/templates/editPost.html
+++ b/app/templates/editPost.html
@@ -24,6 +24,7 @@
             <p class="mb-2">{{translations.editPost.current}}</p>
             <img
                 data-magnet-id="{{ id }}.png"
+                src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw=="
                 class="h-48 w-64 group-hover:scale-110 transition duration-150 object-cover rounded-md mx-auto select-none"
             />
             <p class="mt-2">{{translations.editPost.new}}</p>

--- a/app/templates/post.html
+++ b/app/templates/post.html
@@ -16,7 +16,11 @@
 {% endblock head %}
 {% block body %}
 <div class="w-11/12 md:w-5/6 lg:w-7/12 xl:w-5/12 mx-auto mt-6 md:mt-10 break-words">
-    <img data-magnet-id="{{ id }}.png" class="mx-auto rounded-md shadow-md select-none" />
+    <img
+        data-magnet-id="{{ id }}.png"
+        src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw=="
+        class="mx-auto rounded-md shadow-md select-none"
+    />
     <h1 class="text-2xl md:text-3xl mt-3 text-rose-500 w-full text-center font-bold">{{ title }}</h1>
     <div class="flex items-center justify-center gap-2 my-4 select-none opacity-75">
         <p class="text-sm font-medium"><span id="reading-time">{{ reading_time }}</span> {{ translations.post.minRead }}</p>


### PR DESCRIPTION
## Summary
- Drop `/images` blueprint and all server-based image paths
- Retrieve post images through WebTorrent magnets and render blobs client-side
- Invoke magnet loader after category page renders to display fetched images

## Testing
- `python -m py_compile app/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68af475eb8c483278fbedc7dfd95e771