### PR TITLE
Seed images via background torrent processes

### DIFF
--- a/app/utils/torrent_worker.py
+++ b/app/utils/torrent_worker.py
@@ -1,0 +1,22 @@
+import sys
+import time
+import libtorrent as lt
+
+
+def seed(torrent_path: str, save_path: str) -> None:
+    """Seed ``torrent_path`` in a dedicated libtorrent session."""
+    ses = lt.session()
+    ses.listen_on(6881, 6891)
+    ti = lt.torrent_info(torrent_path)
+    ses.add_torrent({"ti": ti, "save_path": save_path})
+    # Keep the process alive indefinitely to continue seeding
+    while True:
+        time.sleep(3600)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("usage: torrent_worker.py <torrent_path> <save_path>")
+        sys.exit(1)
+    seed(sys.argv[1], sys.argv[2])
+


### PR DESCRIPTION
## Summary
- Launch a dedicated subprocess for each uploaded image to keep its torrent seeding
- Provide a `torrent_worker` helper script that seeds a single torrent indefinitely
- Replace in-process seeding with background processes to improve availability

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af4b1e89bc8327af31fe037dab726c