### PR TITLE
fix: replace placeholder image blob

### DIFF
--- a/app/static/js/magnet.js
+++ b/app/static/js/magnet.js
@@ -36,7 +36,11 @@ async function loadMagnets() {
                 client.add(magnet, (torrent) => {
                     torrent.files[0].getBlob((err, blob) => {
                         if (!err) {
-                            img.src = URL.createObjectURL(blob);
+                            const newUrl = URL.createObjectURL(blob);
+                            if (img.src && img.src.startsWith("blob:")) {
+                                URL.revokeObjectURL(img.src);
+                            }
+                            img.src = newUrl;
                         }
                     });
                 });


### PR DESCRIPTION
## Summary
- ensure magnet-loaded images revoke placeholder blob URLs before setting real content

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af4dcece908327838113ae6bd291c7