### PR TITLE
Fix magnet image loader to update src when magnet is fetched

### DIFF
--- a/app/static/js/magnet.js
+++ b/app/static/js/magnet.js
@@ -1,4 +1,9 @@
-async function loadMagnets() {
+let provider;
+let contract;
+let client;
+
+async function initMagnetClient() {
+    if (client) return;
     if (typeof WebTorrent === "undefined") {
         await new Promise((resolve) => {
             const s = document.createElement("script");
@@ -20,40 +25,69 @@ async function loadMagnets() {
         console.error("RPC URL is not defined");
         return;
     }
-    const provider = new ethers.providers.JsonRpcProvider(url);
-    const contract = new ethers.Contract(
+    provider = new ethers.providers.JsonRpcProvider(url);
+    contract = new ethers.Contract(
         window.postContractAddress,
         window.postContractAbi,
         provider
     );
-    const client = new WebTorrent();
-    const images = document.querySelectorAll("[data-magnet-id]");
-    for (const img of images) {
-        const id = img.dataset.magnetId;
-        try {
-            const magnet = await contract.getImageMagnet(id);
-            if (magnet) {
-                client.add(magnet, (torrent) => {
-                    torrent.files[0].getBlob((err, blob) => {
-                        if (!err) {
-                            const newUrl = URL.createObjectURL(blob);
-                            if (img.src && img.src.startsWith("blob:")) {
-                                URL.revokeObjectURL(img.src);
-                            }
-                            img.src = newUrl;
-                        }
-                    });
+    client = new WebTorrent();
+}
+
+async function fetchMagnet(img) {
+    if (!img || img.dataset.magnetLoaded) return;
+    const id = img.dataset.magnetId;
+    if (!id) return;
+    await initMagnetClient();
+    try {
+        const magnet = await contract.getImageMagnet(id);
+        if (magnet) {
+            client.add(magnet, (torrent) => {
+                torrent.files[0].getBlob((err, blob) => {
+                    if (err) {
+                        console.error("Failed to load magnet", id, err);
+                        return;
+                    }
+                    const newUrl = URL.createObjectURL(blob);
+                    if (img.src && img.src.startsWith("blob:")) {
+                        URL.revokeObjectURL(img.src);
+                    }
+                    img.src = newUrl;
+                    img.dataset.magnetLoaded = "true";
                 });
-            } else {
-                console.warn("No magnet URI returned for", id);
-            }
-        } catch (e) {
-            console.error("Failed to load magnet", id, e);
+            });
+        } else {
+            console.warn("No magnet URI returned for", id);
         }
+    } catch (e) {
+        console.error("Failed to load magnet", id, e);
     }
 }
 
+async function loadMagnets() {
+    await initMagnetClient();
+    const images = document.querySelectorAll("[data-magnet-id]");
+    images.forEach(fetchMagnet);
+}
+
+function observeNewImages() {
+    const observer = new MutationObserver((mutations) => {
+        for (const mutation of mutations) {
+            mutation.addedNodes.forEach((node) => {
+                if (node.nodeType !== 1) return;
+                if (node.dataset && node.dataset.magnetId) {
+                    fetchMagnet(node);
+                }
+                node
+                    .querySelectorAll?.("[data-magnet-id]")
+                    .forEach((el) => fetchMagnet(el));
+            });
+        }
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+}
+
 if (typeof window !== "undefined") {
-    window.loadMagnets = loadMagnets;
-    loadMagnets();
+    window.loadMagnets = () => loadMagnets();
+    loadMagnets().then(observeNewImages);
 }


### PR DESCRIPTION
## Summary
- ensure magnet images replace their placeholders once on-chain magnet URIs are loaded
- watch DOM for new `[data-magnet-id]` images so dynamic content loads magnets automatically

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af4f07a4948327837f3ad60523dacd