### PR TITLE
Fix infinite recursion in magnet loader

### DIFF
--- a/app/static/js/magnet.js
+++ b/app/static/js/magnet.js
@@ -88,6 +88,6 @@ function observeNewImages() {
 }
 
 if (typeof window !== "undefined") {
-    window.loadMagnets = () => loadMagnets();
+    window.loadMagnets = loadMagnets;
     loadMagnets().then(observeNewImages);
 }


### PR DESCRIPTION
## Summary
- Prevent `window.loadMagnets` from recursively calling itself by assigning the function directly

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af50466a4883279a52de93a9f9c1f0