### PR TITLE
Render torrent files inline in browser

### DIFF
--- a/app/static/js/torrentSeeder.js
+++ b/app/static/js/torrentSeeder.js
@@ -15,6 +15,25 @@
         try {
             client.add(link.href, (torrent) => {
                 console.log('Seeding', torrent.infoHash);
+
+                if (torrent.files && torrent.files.length > 0) {
+                    // Create container to hold rendered content
+                    const container = document.createElement('div');
+                    link.parentNode.insertBefore(container, link);
+
+                    torrent.files[0].appendTo(
+                        container,
+                        { autoplay: true, controls: true },
+                        (err) => {
+                            if (err) {
+                                console.error('Error rendering torrent', link.href, err);
+                            }
+                        }
+                    );
+
+                    // Remove placeholder link once content is rendered
+                    link.remove();
+                }
             });
         } catch (err) {
             console.error('Error adding torrent', link.href, err);


### PR DESCRIPTION
## Summary
- replace placeholder .torrent links with inline-rendered content using WebTorrent

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af5c48327c832790ca16130c5abd33