### PR TITLE
feat: add extensive frontend debugging

### DIFF
--- a/app/static/js/adminCheck.js
+++ b/app/static/js/adminCheck.js
@@ -1,5 +1,12 @@
+const debug = (...args) => window.debugLog('adminCheck.js', ...args);
+debug('Loaded');
+
 (function() {
+    debug('Checking admin wallet');
     if (!document.body.classList.contains('admin-wallet')) {
+        debug('Admin wallet not found, redirecting');
         window.location.replace('/');
+    } else {
+        debug('Admin wallet present');
     }
 })();

--- a/app/static/js/createPost.js
+++ b/app/static/js/createPost.js
@@ -1,19 +1,28 @@
+const debug = (...args) => window.debugLog('createPost.js', ...args);
+debug('Loaded');
+
 // Handle on-chain post creation before form submission
 window.addEventListener('DOMContentLoaded', () => {
+    debug('DOMContentLoaded');
     const form = document.querySelector('form');
-    if (!form) return;
+    if (!form) {
+        debug('No form found');
+        return;
+    }
 
     let submitting = false;
     form.addEventListener('submit', async (e) => {
+        debug('Submit triggered', { submitting });
         if (submitting) return;
 
         const bannerInput = form.querySelector('input[name="postBanner"]');
         const magnetField = form.querySelector('input[name="postBannerMagnet"]');
         if (bannerInput && bannerInput.files.length && magnetField && !magnetField.value) {
-            // Wait for bannerMagnet.js to generate the magnet and resubmit
+            debug('Waiting for banner magnet');
             return;
         }
         if (typeof window.ethereum === 'undefined' || typeof postContractAddress === 'undefined') {
+            debug('Ethereum or contract address undefined');
             return;
         }
         e.preventDefault();
@@ -30,7 +39,9 @@ window.addEventListener('DOMContentLoaded', () => {
             const signer = provider.getSigner();
             const contract = new ethers.Contract(postContractAddress, postContractAbi, signer);
             const tx = await contract.createPost(payload, magnet);
+            debug('Transaction sent', tx.hash);
             const receipt = await tx.wait();
+            debug('Transaction mined', receipt.transactionHash);
             let postId;
             try {
                 const event = receipt.events.find(e => e.event === 'PostCreated');
@@ -42,13 +53,14 @@ window.addEventListener('DOMContentLoaded', () => {
                 try {
                     const tx2 = await contract.setImageMagnet(`${postId}.png`, magnet);
                     await tx2.wait();
+                    debug('Image magnet set');
                 } catch (err) {
-                    console.error('Failed to set image magnet', err);
+                    debug('Failed to set image magnet', err);
                 }
             }
             window.location.href = '/';
         } catch (err) {
-            console.error('Failed to create post on-chain', err);
+            debug('Failed to create post on-chain', err);
         }
         submitting = true;
     });

--- a/app/static/js/debug.js
+++ b/app/static/js/debug.js
@@ -1,0 +1,44 @@
+// Global debugging utilities
+(function () {
+    function debugLog(source, ...args) {
+        const time = new Date().toISOString();
+        console.debug(`[${time}] [${source}]`, ...args);
+    }
+    window.debugLog = debugLog;
+
+    // Log all fetch requests and responses
+    if (window.fetch) {
+        const originalFetch = window.fetch;
+        window.fetch = async function (...args) {
+            debugLog('fetch', ...args);
+            try {
+                const response = await originalFetch.apply(this, args);
+                debugLog('fetch:response', response);
+                return response;
+            } catch (err) {
+                debugLog('fetch:error', err);
+                throw err;
+            }
+        };
+    }
+
+    // Log event listener registrations and dispatches
+    const origAddEventListener = EventTarget.prototype.addEventListener;
+    EventTarget.prototype.addEventListener = function (type, listener, options) {
+        const wrapped = function (...evtArgs) {
+            debugLog(`event:${type}`, this);
+            return listener.apply(this, evtArgs);
+        };
+        debugLog('addEventListener', this, type);
+        return origAddEventListener.call(this, type, wrapped, options);
+    };
+
+    // Log unhandled errors
+    window.addEventListener('error', (e) => {
+        debugLog('error', e.message, e.filename, e.lineno, e.colno);
+    });
+    window.addEventListener('unhandledrejection', (e) => {
+        debugLog('unhandledrejection', e.reason);
+    });
+})();
+

--- a/app/static/js/markdownEditor.js
+++ b/app/static/js/markdownEditor.js
@@ -1,7 +1,14 @@
+const debug = (...args) => window.debugLog('markdownEditor.js', ...args);
+debug('Loaded');
+
 // Markdown Editor with Toolbar
 document.addEventListener('DOMContentLoaded', function() {
+    debug('DOMContentLoaded');
     const textarea = document.getElementById('markdown-editor');
-    if (!textarea) return;
+    if (!textarea) {
+        debug('No textarea found');
+        return;
+    }
     
     // Create editor container
     const container = document.createElement('div');
@@ -87,6 +94,7 @@ Use **bold**, *italic*, and other markdown features.
     // Character count
     function updateCharCount() {
         const count = textarea.value.length;
+        debug('updateCharCount', count);
         document.getElementById('char-count').textContent = count + ' characters';
     }
     
@@ -99,9 +107,9 @@ Use **bold**, *italic*, and other markdown features.
         const end = textarea.selectionEnd;
         const selectedText = textarea.value.substring(start, end);
         const newText = before + selectedText + after;
-        
+        debug('insertText', { before, after, selectedText });
         textarea.value = textarea.value.substring(0, start) + newText + textarea.value.substring(end);
-        
+
         // Set cursor position
         const newCursorPos = start + before.length + selectedText.length;
         textarea.setSelectionRange(newCursorPos, newCursorPos);
@@ -111,6 +119,7 @@ Use **bold**, *italic*, and other markdown features.
     
     // Keyboard shortcuts
     textarea.addEventListener('keydown', function(e) {
+        debug('keydown', e.key);
         if (e.ctrlKey || e.metaKey) {
             switch(e.key) {
                 case 'b':
@@ -127,11 +136,11 @@ Use **bold**, *italic*, and other markdown features.
                     break;
             }
         }
-        
+
         // Tab support
         if (e.key === 'Tab') {
             e.preventDefault();
             insertText('    ', '');
         }
     });
-}); 
+});

--- a/app/static/js/metamaskLogin.js
+++ b/app/static/js/metamaskLogin.js
@@ -1,27 +1,36 @@
+const debug = (...args) => window.debugLog('metamaskLogin.js', ...args);
+debug('Loaded');
+
 async function loginWithMetaMask(redirectUrl) {
+    debug('loginWithMetaMask called', redirectUrl);
     if (typeof window.ethereum === 'undefined') {
+        debug('MetaMask not detected');
         alert('MetaMask not detected');
         return;
     }
     try {
         const accounts = await window.ethereum.request({ method: 'eth_requestAccounts' });
+        debug('Accounts', accounts);
         const address = accounts[0];
         const message = 'Log in to FlaskBlog';
         const signature = await window.ethereum.request({
             method: 'personal_sign',
             params: [message, address],
         });
+        debug('Signature obtained');
         const resp = await fetch(`/login?redirect=${encodeURIComponent(redirectUrl)}`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrfToken },
             body: JSON.stringify({ address, signature }),
         });
+        debug('Server response status', resp.status);
         const data = await resp.json();
+        debug('Server response data', data);
         if (data.redirect) {
             window.location = data.redirect;
         }
     } catch (err) {
-        console.error('MetaMask login failed', err);
+        debug('MetaMask login failed', err);
     }
 }
 

--- a/app/static/js/navbar.js
+++ b/app/static/js/navbar.js
@@ -1,9 +1,16 @@
+const debug = (...args) => window.debugLog('navbar.js', ...args);
+debug('Loaded');
+
 function search() {
   const input = document.querySelector("#searchInput").value;
+  debug('search', input);
   if (input === "" || input.trim() === "") {
+    debug('Empty search submitted');
   } else {
-    window.location.href = `/search/${encodeURIComponent(
+    const url = `/search/${encodeURIComponent(
       escape(input.trim()),
     )}`;
+    debug('Redirecting to', url);
+    window.location.href = url;
   }
 }

--- a/app/static/js/postConfig.js
+++ b/app/static/js/postConfig.js
@@ -1,2 +1,5 @@
+const debug = (...args) => window.debugLog('postConfig.js', ...args);
+debug('Loaded');
+
 // Post Configuration Variables
-// This file is loaded dynamically with template variables injected 
+// This file is loaded dynamically with template variables injected

--- a/app/static/js/postContent.js
+++ b/app/static/js/postContent.js
@@ -1,4 +1,8 @@
+const debug = (...args) => window.debugLog('postContent.js', ...args);
+debug('Loaded');
+
 (async () => {
+    debug('Loading post content');
     if (typeof ethers === 'undefined') {
         await new Promise((resolve) => {
             const s = document.createElement('script');
@@ -19,10 +23,12 @@
     const contract = new ethers.Contract(postContractAddress, postContractAbi, provider);
     try {
         const p = await contract.getPost(postUrlID);
+        debug('Fetched post', p);
         const content = p.contentHash;
         const contentEl = document.getElementById('post-content');
         if (contentEl) {
             contentEl.innerHTML = marked.parse(content);
+            debug('Rendered content');
         }
         const cleanText = content.replace(/<[^>]+>/g, '');
         const words = cleanText.trim().split(/\s+/).filter(Boolean).length;
@@ -30,8 +36,9 @@
         const rtEl = document.getElementById('reading-time');
         if (rtEl) {
             rtEl.textContent = minutes.toString();
+            debug('Reading time set', minutes);
         }
     } catch (err) {
-        console.error('Failed to load post content', err);
+        debug('Failed to load post content', err);
     }
 })();

--- a/app/static/js/postOverlay.js
+++ b/app/static/js/postOverlay.js
@@ -1,15 +1,21 @@
+const debug = (...args) => window.debugLog('postOverlay.js', ...args);
+debug('Loaded');
+
 (function () {
+    debug('postOverlay init');
     const overlay = document.getElementById('post-overlay');
     const iframe = document.getElementById('post-iframe');
     const closeBtn = overlay.querySelector('.overlay-close');
 
     function openOverlay(url) {
+        debug('openOverlay', url);
         iframe.src = url;
         overlay.classList.remove('hidden');
         requestAnimationFrame(() => overlay.classList.add('show'));
     }
 
     function closeOverlay() {
+        debug('closeOverlay');
         overlay.classList.remove('show');
         iframe.src = '';
         setTimeout(() => overlay.classList.add('hidden'), 300);
@@ -19,6 +25,7 @@
         const link = e.target.closest('a');
         if (!link || !link.href) return;
         const url = new URL(link.href, window.location.origin);
+        debug('link click', url.pathname);
         if (url.pathname.startsWith('/post/')) {
             e.preventDefault();
             openOverlay(url.href);
@@ -27,6 +34,7 @@
 
     overlay.addEventListener('click', function (e) {
         if (e.target === overlay) {
+            debug('overlay background click');
             closeOverlay();
         }
     });

--- a/app/static/js/postsAnalytics.js
+++ b/app/static/js/postsAnalytics.js
@@ -1,3 +1,6 @@
+const debug = (...args) => window.debugLog('postsAnalytics.js', ...args);
+debug('Loaded');
+
 window.Promise ||
   document.write(
     '<script src="https://cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js"><\/script>',
@@ -21,6 +24,7 @@ let lineChartErrorContainer = document.getElementById(
 );
 
 function startDropDownMenu() {
+  debug('startDropDownMenu');
   document
     .getElementById("durationRangeTab")
     .addEventListener("change", durationRangeCallback, false);
@@ -38,6 +42,7 @@ let durationRangeMap = {
 
 function durationRangeCallback() {
   let selectedDurationRange = document.getElementById("durationRangeTab").value;
+  debug('durationRangeCallback', selectedDurationRange);
   let dropDownMenuSpinner = document.getElementById("dropDownMenuSpinner");
 
   onTabDurationSelection(
@@ -48,6 +53,7 @@ function durationRangeCallback() {
 
 let initialStateTabId = "last48h";
 function changeTabState(tabID) {
+  debug('changeTabState', tabID);
   document
     .getElementById(initialStateTabId)
     .classList.remove("bg-rose-500/75", "text-black");
@@ -75,6 +81,7 @@ function changeTabState(tabID) {
 }
 
 async function onTabDurationSelection(durationRangeQuery, spinnerID) {
+  debug('onTabDurationSelection', durationRangeQuery);
   spinnerID.classList.remove("hidden");
 
   refreshedLineGraphData = await fetchTrafficGraphData(durationRangeQuery);
@@ -93,6 +100,7 @@ async function onTabDurationSelection(durationRangeQuery, spinnerID) {
 }
 
 async function fetchTrafficGraphData(durationRangeQuery) {
+  debug('fetchTrafficGraphData', durationRangeQuery);
   try {
     let response = await fetch(
       postAnalyticsDataTrafficGraphUrl + durationRangeQuery,
@@ -102,16 +110,17 @@ async function fetchTrafficGraphData(durationRangeQuery) {
     if (response.ok) {
       return responseData.payload;
     } else {
-      console.error(responseData.message);
+      debug('Traffic graph error', responseData.message);
       return null;
     }
   } catch (error) {
-    console.error(error);
+    debug('fetchTrafficGraphData error', error);
     return null;
   }
 }
 
 async function loadLineChart(durationRangeQuery) {
+  debug('loadLineChart', durationRangeQuery);
   lineChartSpinner.classList.remove("hidden");
 
   let lineGraphData = await fetchTrafficGraphData(durationRangeQuery);
@@ -236,22 +245,24 @@ let viewAllSpinner = document.getElementById("viewAllSpinner");
 let barChartErrorContainer = document.getElementById("barChartErrorContainer");
 
 async function fetchCountryGraphData(dataLimit) {
+  debug('fetchCountryGraphData', dataLimit);
   try {
     let response = await fetch(postAnalyticsDataCountryGraphUrl + dataLimit);
     let responseData = await response.json();
     if (response.ok) {
       return responseData.payload;
     } else {
-      console.error(responseData.message);
+      debug(responseData.message);
       return null;
     }
   } catch (error) {
-    console.error(error);
+    debug('fetchCountryGraphData error', error);
     return null;
   }
 }
 
 async function loadBarChart(dataLimit) {
+  debug('loadBarChart', dataLimit);
   const countryGraphData = await fetchCountryGraphData(dataLimit);
   let lengthOfCountryList = countryGraphData["countryCountList"].length;
 
@@ -312,6 +323,7 @@ async function loadBarChart(dataLimit) {
 }
 
 async function onViewAllClick() {
+  debug('onViewAllClick');
   viewAllSpinner.classList.remove("hidden");
   let refreshedCountryData = await fetchCountryGraphData("viewAll=True");
 

--- a/app/static/js/progress.js
+++ b/app/static/js/progress.js
@@ -1,8 +1,12 @@
+const debug = (...args) => window.debugLog('progress.js', ...args);
+debug('Loaded');
+
 document.addEventListener('scroll', () => {
   const doc = document.documentElement;
   const scrollTop = doc.scrollTop;
   const scrollHeight = doc.scrollHeight - doc.clientHeight;
   const progress = scrollHeight ? (scrollTop / scrollHeight) * 100 : 0;
+  debug('scroll', { scrollTop, progress });
   const bar = document.getElementById('progress-bar');
   if (bar) {
     bar.style.width = progress + '%';

--- a/app/static/js/readerControls.js
+++ b/app/static/js/readerControls.js
@@ -1,4 +1,8 @@
+const debug = (...args) => window.debugLog('readerControls.js', ...args);
+debug('Loaded');
+
 document.addEventListener('DOMContentLoaded', () => {
+  debug('DOMContentLoaded');
   const root = document.documentElement;
 
   // Theme handling
@@ -23,6 +27,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const next = current === 'dark' ? 'light' : 'dark';
       root.setAttribute('data-theme', next);
       localStorage.setItem('theme', next);
+      debug('themeToggle', next);
     });
   }
 
@@ -34,6 +39,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const applySize = () => {
     root.style.fontSize = fontSize + '%';
     localStorage.setItem('fontSize', fontSize);
+    debug('applySize', fontSize);
   };
   applySize();
 
@@ -42,12 +48,14 @@ document.addEventListener('DOMContentLoaded', () => {
   if (incBtn) {
     incBtn.addEventListener('click', () => {
       fontSize = Math.min(fontSize + 10, 300);
+      debug('font increment', fontSize);
       applySize();
     });
   }
   if (decBtn) {
     decBtn.addEventListener('click', () => {
       fontSize = Math.max(fontSize - 10, 50);
+      debug('font decrement', fontSize);
       applySize();
     });
   }
@@ -58,6 +66,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const audioUrl = listenBtn.dataset.audio;
     const audio = new Audio(audioUrl);
     listenBtn.addEventListener('click', () => {
+      debug('play audio', audioUrl);
       audio.play();
     });
   }

--- a/app/static/js/recaptcha.js
+++ b/app/static/js/recaptcha.js
@@ -1,3 +1,7 @@
+const debug = (...args) => window.debugLog('recaptcha.js', ...args);
+debug('Loaded');
+
 function onSubmit(token) {
+  debug('recaptcha onSubmit', token);
   document.getElementById("recaptchaForm").submit();
 }

--- a/app/static/js/searchBar.js
+++ b/app/static/js/searchBar.js
@@ -1,9 +1,16 @@
+const debug = (...args) => window.debugLog('searchBar.js', ...args);
+debug('Loaded');
+
 function searchBar() {
   const input = document.querySelector("#searchBarInput").value;
+  debug('searchBar', input);
   if (input === "" || input.trim() === "") {
+    debug('Empty search');
   } else {
-    window.location.href = `/search/${encodeURIComponent(
+    const url = `/search/${encodeURIComponent(
       escape(input.trim()),
     )}`;
+    debug('Redirecting to', url);
+    window.location.href = url;
   }
 }

--- a/app/static/js/timeStamp.js
+++ b/app/static/js/timeStamp.js
@@ -1,8 +1,12 @@
+const debug = (...args) => window.debugLog('timeStamp.js', ...args);
+debug('Loaded');
+
 const timeElements = document.getElementsByClassName("time");
 const dateElements = document.getElementsByClassName("date");
 
 function formatTimeElement(element) {
   let unixTimeStamp = element.innerText;
+  debug('formatTimeElement', unixTimeStamp);
 
   let dateObject = new Date(unixTimeStamp * 1000);
 
@@ -16,6 +20,7 @@ function formatTimeElement(element) {
 
 function formatDateElement(element) {
   let unixTimeStamp = element.innerText;
+  debug('formatDateElement', unixTimeStamp);
 
   let dateObject = new Date(unixTimeStamp * 1000);
 
@@ -30,9 +35,11 @@ function formatDateElement(element) {
 }
 
 for (element of timeElements) {
+  debug('Processing time element', element);
   formatTimeElement(element);
 }
 
 for (element of dateElements) {
+  debug('Processing date element', element);
   formatDateElement(element);
 }

--- a/app/static/js/torrentSeeder.js
+++ b/app/static/js/torrentSeeder.js
@@ -1,4 +1,8 @@
+const debug = (...args) => window.debugLog('torrentSeeder.js', ...args);
+debug('Loaded');
+
 (async () => {
+    debug('torrentSeeder init');
     if (typeof WebTorrent === 'undefined') {
         await new Promise((resolve) => {
             const script = document.createElement('script');
@@ -11,10 +15,11 @@
     const client = new WebTorrent();
     window.torrentClient = client; // keep reference
     const links = document.querySelectorAll('a[href$=".torrent"]');
+    debug('Found torrent links', links.length);
     links.forEach((link) => {
         try {
             client.add(link.href, (torrent) => {
-                console.log('Seeding', torrent.infoHash);
+                debug('Seeding', torrent.infoHash);
 
                 if (torrent.files && torrent.files.length > 0) {
                     // Create container to hold rendered content
@@ -26,17 +31,18 @@
                         { autoplay: true, controls: true },
                         (err) => {
                             if (err) {
-                                console.error('Error rendering torrent', link.href, err);
+                                debug('Error rendering torrent', link.href, err);
                             }
                         }
                     );
 
                     // Remove placeholder link once content is rendered
                     link.remove();
+                    debug('Rendered torrent content');
                 }
             });
         } catch (err) {
-            console.error('Error adding torrent', link.href, err);
+            debug('Error adding torrent', link.href, err);
         }
     });
 })();

--- a/app/static/js/wallet.js
+++ b/app/static/js/wallet.js
@@ -1,13 +1,20 @@
+const debug = (...args) => window.debugLog('wallet.js', ...args);
+debug('Loaded');
+
 const ADMIN_ADDRESS = "0xB2b36AaD18d7be5d4016267BC4cCec2f12a64b6e".toLowerCase();
 
 async function connectWallet() {
+    debug('connectWallet called');
     if (typeof window.ethereum === 'undefined') {
+        debug('No ethereum provider');
         return;
     }
     try {
         const accounts = await window.ethereum.request({ method: 'eth_requestAccounts' });
+        debug('Accounts', accounts);
         const account = accounts[0]?.toLowerCase();
         if (!account) {
+            debug('No account returned');
             return;
         }
         window.userAddress = account;
@@ -22,9 +29,11 @@ async function connectWallet() {
         }
         if (account === ADMIN_ADDRESS) {
             document.body.classList.add('admin-wallet');
+            debug('Admin wallet detected');
         }
+        debug('Wallet connected', account);
     } catch (err) {
-        console.error('Wallet connection failed', err);
+        debug('Wallet connection failed', err);
     }
 }
 

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -88,6 +88,7 @@
             crossorigin="anonymous"
         ></script>
 
+        <script src="{{ url_for('static', filename='js/debug.js') }}"></script>
         <script src="{{ url_for('static', filename='js/wallet.js') }}"></script>
         {% if admin_check %}
         <script src="{{ url_for('static', filename='js/adminCheck.js') }}"></script>


### PR DESCRIPTION
## Summary
- add global debug script that logs fetches, events and errors
- instrument all frontend JavaScript with file-scoped debug helpers
- wire debug.js into the base layout so every page captures detailed logs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af9e080fa48327b3f99ff46f9855ab