### PR TITLE
Simplify front-end debug logging

### DIFF
--- a/app/static/js/debug.js
+++ b/app/static/js/debug.js
@@ -1,44 +1,7 @@
-// Global debugging utilities
-(function () {
-    function debugLog(source, ...args) {
-        const time = new Date().toISOString();
-        console.debug(`[${time}] [${source}]`, ...args);
-    }
-    window.debugLog = debugLog;
-
-    // Log all fetch requests and responses
-    if (window.fetch) {
-        const originalFetch = window.fetch;
-        window.fetch = async function (...args) {
-            debugLog('fetch', ...args);
-            try {
-                const response = await originalFetch.apply(this, args);
-                debugLog('fetch:response', response);
-                return response;
-            } catch (err) {
-                debugLog('fetch:error', err);
-                throw err;
-            }
-        };
-    }
-
-    // Log event listener registrations and dispatches
-    const origAddEventListener = EventTarget.prototype.addEventListener;
-    EventTarget.prototype.addEventListener = function (type, listener, options) {
-        const wrapped = function (...evtArgs) {
-            debugLog(`event:${type}`, this);
-            return listener.apply(this, evtArgs);
-        };
-        debugLog('addEventListener', this, type);
-        return origAddEventListener.call(this, type, wrapped, options);
-    };
-
-    // Log unhandled errors
-    window.addEventListener('error', (e) => {
-        debugLog('error', e.message, e.filename, e.lineno, e.colno);
-    });
-    window.addEventListener('unhandledrejection', (e) => {
-        debugLog('unhandledrejection', e.reason);
-    });
+// Simple global debug logger
+(() => {
+  window.debugLog = function(source, ...args) {
+    const time = new Date().toISOString();
+    console.log(`[${time}] [${source}]`, ...args);
+  };
 })();
-

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -28,6 +28,7 @@
             type="text/css"
         />
         <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+        <script src="{{ url_for('static', filename='js/debug.js') }}"></script>
 
         <link
             rel="stylesheet"
@@ -88,7 +89,6 @@
             crossorigin="anonymous"
         ></script>
 
-        <script src="{{ url_for('static', filename='js/debug.js') }}"></script>
         <script src="{{ url_for('static', filename='js/wallet.js') }}"></script>
         {% if admin_check %}
         <script src="{{ url_for('static', filename='js/adminCheck.js') }}"></script>


### PR DESCRIPTION
## Summary
- Load debug utility before other scripts
- Replace debug.js with minimal console-based logger

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68afac2057448327ae31374d27ae5543