### PR TITLE
Simplify torrent seeding worker

### DIFF
--- a/app/utils/torrent.py
+++ b/app/utils/torrent.py
@@ -4,11 +4,11 @@ import sys
 import libtorrent as lt
 
 
-def _spawn_seeder(torrent_path: str, save_path: str) -> None:
+def _spawn_seeder(torrent_path: str) -> None:
     """Launch a background process to seed ``torrent_path``."""
     worker = os.path.join(os.path.dirname(__file__), "torrent_worker.py")
     subprocess.Popen(
-        [sys.executable, worker, torrent_path, save_path],
+        [sys.executable, worker, torrent_path],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
         close_fds=True,
@@ -29,7 +29,7 @@ def seed_file(file_path: str) -> str:
         f.write(lt.bencode(torrent))
     ti = lt.torrent_info(torrent_path)
     magnet = lt.make_magnet_uri(ti)
-    _spawn_seeder(torrent_path, base_path)
+    _spawn_seeder(torrent_path)
     return magnet
 
 
@@ -41,5 +41,5 @@ def ensure_seeding(directory: str) -> None:
         if not name.endswith(".torrent"):
             continue
         torrent_path = os.path.join(directory, name)
-        _spawn_seeder(torrent_path, directory)
+        _spawn_seeder(torrent_path)
 

--- a/app/utils/torrent_worker.py
+++ b/app/utils/torrent_worker.py
@@ -1,22 +1,37 @@
+import os
 import sys
 import time
 import libtorrent as lt
 
 
-def seed(torrent_path: str, save_path: str) -> None:
-    """Seed ``torrent_path`` in a dedicated libtorrent session."""
+def seed(torrent_path: str) -> None:
+    """Seed ``torrent_path`` in a dedicated libtorrent session.
+
+    The files to be seeded are assumed to live alongside the ``.torrent``
+    file. This removes the need to explicitly provide a ``save_path``.
+    """
+
+    # Determine where the content lives based on the torrent file location
+    save_path = os.path.dirname(os.path.abspath(torrent_path)) or os.getcwd()
+
     ses = lt.session()
-    ses.listen_on(6881, 6891)
+
+    # ``listen_on`` is deprecated; configure the interface via settings pack
+    settings = lt.settings_pack()
+    settings.set_str("listen_interfaces", "0.0.0.0:6881")
+    ses.apply_settings(settings)
+
     ti = lt.torrent_info(torrent_path)
     ses.add_torrent({"ti": ti, "save_path": save_path})
+
     # Keep the process alive indefinitely to continue seeding
     while True:
         time.sleep(3600)
 
 
 if __name__ == "__main__":
-    if len(sys.argv) != 3:
-        print("usage: torrent_worker.py <torrent_path> <save_path>")
+    if len(sys.argv) != 2:
+        print("usage: torrent_worker.py <torrent_path>")
         sys.exit(1)
-    seed(sys.argv[1], sys.argv[2])
+    seed(sys.argv[1])
 


### PR DESCRIPTION
## Summary
- Allow `torrent_worker.py` to infer the save path from the torrent file location and configure listening via `settings_pack`
- Adjust seeding utilities to call worker without an explicit save path

## Testing
- `python -m py_compile app/utils/torrent_worker.py app/utils/torrent.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68afaf61aa8c8327b7a2a12cc6553819