### PR TITLE
Use WebTorrent CLI for seeding torrents

### DIFF
--- a/app/utils/torrent_worker.py
+++ b/app/utils/torrent_worker.py
@@ -1,40 +1,33 @@
 import os
 import sys
-import time
-import libtorrent as lt
+import subprocess
 
 
 def seed(torrent_path: str) -> None:
-    """Seed ``torrent_path`` in a dedicated libtorrent session.
+    """Seed ``torrent_path`` using the WebTorrent CLI.
 
-    The files to be seeded are assumed to live alongside the ``.torrent``
-    file. This removes the need to explicitly provide a ``save_path``.
+    The files referenced by the ``.torrent`` file are expected to live
+    alongside it. The WebTorrent command line tool is used to verify the
+    files and keep them seeding indefinitely.
     """
 
-    # Determine where the content lives based on the torrent file location
     save_path = os.path.dirname(os.path.abspath(torrent_path)) or os.getcwd()
 
-    ses = lt.session()
+    cmd = [
+        "webtorrent",
+        "download",
+        torrent_path,
+        "--keep-seeding",
+        "--out",
+        save_path,
+    ]
 
-    # ``listen_on`` is deprecated in newer libtorrent versions, which
-    # instead use ``settings_pack`` to configure interfaces.  Older Python
-    # bindings, however, don't expose ``settings_pack``.  Support both
-    # scenarios so the worker can run regardless of the installed
-    # libtorrent version.
+    proc = subprocess.Popen(cmd)
     try:
-        settings = lt.settings_pack()
-        settings.set_str("listen_interfaces", "0.0.0.0:6881")
-        ses.apply_settings(settings)
-    except AttributeError:
-        # Fall back to the legacy ``listen_on`` API
-        ses.listen_on(6881, 6881)
-
-    ti = lt.torrent_info(torrent_path)
-    ses.add_torrent({"ti": ti, "save_path": save_path})
-
-    # Keep the process alive indefinitely to continue seeding
-    while True:
-        time.sleep(3600)
+        proc.wait()
+    except KeyboardInterrupt:
+        proc.terminate()
+        proc.wait()
 
 
 if __name__ == "__main__":
@@ -42,4 +35,3 @@ if __name__ == "__main__":
         print("usage: torrent_worker.py <torrent_path>")
         sys.exit(1)
     seed(sys.argv[1])
-


### PR DESCRIPTION
## Summary
- Replace libtorrent-based seeding worker with a wrapper around the WebTorrent CLI
- Invoke `webtorrent download --keep-seeding` so existing files continue seeding indefinitely

## Testing
- `python -m py_compile app/utils/torrent_worker.py`


------
https://chatgpt.com/codex/tasks/task_e_68afb4a005288327bdb12f70efe941c9