### PR TITLE
Fix torrent image loading and show new posts

### DIFF
--- a/app/static/js/loadPosts.js
+++ b/app/static/js/loadPosts.js
@@ -22,7 +22,7 @@
     try {
         const nextId = (await contract.nextPostId()).toNumber();
         debug('Next post id', nextId);
-        for (let id = 0; id < nextId; id++) {
+        for (let id = nextId - 1; id >= 0; id--) {
             let p;
             try {
                 // Use the public mapping to avoid reverts for missing posts


### PR DESCRIPTION
## Summary
- Ensure WebTorrent images load once and render across multiple instances
- Retrieve posts from blockchain in reverse order so newest posts display first

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68afc3f5a8388327898daf0c4a4fc479