### PR TITLE
Fix missing closing bracket in createPost.js

### DIFF
--- a/app/static/js/createPost.js
+++ b/app/static/js/createPost.js
@@ -65,4 +65,5 @@
         }
         submitting = true;
     });
+    });
 })();


### PR DESCRIPTION
## Summary
- fix syntax error in createPost.js by closing DOMContentLoaded handler so form submission logic runs

## Testing
- `pytest`
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afca013f2c8327810a56b3c750089a