### PR TITLE
Restyle front page tiles

### DIFF
--- a/app/static/css/postTiles.css
+++ b/app/static/css/postTiles.css
@@ -1,7 +1,8 @@
+/* Layout */
 .post-tiles-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(15rem, 1fr));
-    grid-auto-rows: 10rem;
+    grid-template-columns: repeat(auto-fill, minmax(20rem, 1fr));
+    grid-auto-rows: 12rem;
     grid-auto-flow: dense;
     gap: 1rem;
 }
@@ -13,62 +14,60 @@
     overflow: hidden;
     border-radius: 0.5rem;
     cursor: pointer;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
 }
 
 .post-tile img {
     position: absolute;
-    top: 0;
-    left: 0;
+    inset: 0;
     width: 100%;
     height: 100%;
     object-fit: cover;
+    transition: transform 0.4s ease;
+}
+
+.post-tile:hover img {
+    transform: scale(1.05);
 }
 
 .tile-title-bar {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    width: 100%;
-    background: rgba(0, 0, 0, 0.6);
-    color: #fff;
-    padding: 0.5rem 1rem;
+    display: none;
 }
 
 .tile-title {
     font-size: 1.25rem;
     font-weight: 700;
-    background: rgba(239, 68, 68, 0.8);
-    padding: 0 0.25rem;
-    border-radius: 0.25rem;
+    margin: 0;
 }
 
 .tile-overlay {
     position: absolute;
     inset: 0;
-    background: rgba(0, 0, 0, 0.85);
-    color: #fff;
     display: flex;
     flex-direction: column;
-    justify-content: center;
-    align-items: center;
+    justify-content: flex-end;
     padding: 1rem;
-    transform: translateY(100%);
-    transition: transform 0.3s ease;
+    color: #fff;
+    background: linear-gradient(to top, rgba(0, 0, 0, 0.75), rgba(0, 0, 0, 0));
+    transition: background 0.3s ease;
 }
 
 .post-tile:hover .tile-overlay {
-    transform: translateY(0);
+    background: linear-gradient(to top, rgba(0, 0, 0, 0.85), rgba(0, 0, 0, 0.2));
 }
 
-.tile-overlay .tile-category,
-.tile-overlay .tile-views {
-    font-size: 0.875rem;
+.tile-category {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #ff6633;
+    margin-top: 0.5rem;
+}
+
+.tile-views {
+    font-size: 0.75rem;
     margin-top: 0.25rem;
-}
-
-.tile-overlay .tile-title {
-    background: none;
-    margin-bottom: 0.5rem;
+    color: rgba(255, 255, 255, 0.8);
 }
 
 .tile-small {

--- a/app/static/js/loadPosts.js
+++ b/app/static/js/loadPosts.js
@@ -50,14 +50,6 @@
             img.className = 'select-none';
             link.appendChild(img);
 
-            const titleBar = document.createElement('div');
-            titleBar.className = 'tile-title-bar';
-            const titleEl = document.createElement('h2');
-            titleEl.className = 'tile-title';
-            titleEl.textContent = title;
-            titleBar.appendChild(titleEl);
-            link.appendChild(titleBar);
-
             const overlay = document.createElement('div');
             overlay.className = 'tile-overlay';
             const overlayTitle = document.createElement('h2');

--- a/app/templates/components/postCardMacro.html
+++ b/app/templates/components/postCardMacro.html
@@ -10,9 +10,6 @@
         alt="{{ post[1] }}"
         class="select-none"
     />
-    <div class="tile-title-bar">
-        <h2 class="tile-title">{{ post[1] }}</h2>
-    </div>
     <div class="tile-overlay">
         <h2 class="tile-title">{{ post[1] }}</h2>
         <span class="tile-category">Category: {{ post[9] }}</span>


### PR DESCRIPTION
## Summary
- Restyle post tile CSS with larger grid columns, gradient overlays, and hover zoom
- Remove redundant title bar in post tiles and display information in a bottom gradient

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68afcfeef4b08327b26ab8e63ecd072e