### PR TITLE
Implement masonry grid layout for post tiles

### DIFF
--- a/app/static/css/postTiles.css
+++ b/app/static/css/postTiles.css
@@ -1,45 +1,44 @@
-/* Layout */
+:root {
+    --gap: 14px; /* space between tiles */
+    --row: 10px; /* base row height for auto row spanning */
+    --minCol: 220px; /* minimum column width */
+}
+
+/* Container: CSS Grid Masonry with dense packing */
 .post-tiles-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(15rem, 25rem));
-    grid-auto-rows: minmax(10rem, 25rem);
+    grid-template-columns: repeat(auto-fill, minmax(var(--minCol), 1fr));
+    grid-auto-rows: var(--row);
     grid-auto-flow: dense;
-    gap: 1rem;
+    gap: var(--gap);
 }
 
+/* Tile card */
 .post-tile {
     position: relative;
-    width: 100%;
-    height: 100%;
-    overflow: hidden;
+    display: block;
     border-radius: 0.5rem;
+    overflow: hidden;
     cursor: pointer;
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+    grid-column: span var(--col-span, 1);
+    grid-row: span var(--row-span, 1);
+    transition: transform 0.15s ease, box-shadow 0.2s ease;
 }
 
-.post-tile img {
-    position: absolute;
-    inset: 0;
+.post-tile:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 16px rgba(0, 0, 0, 0.2);
+}
+
+/* Media */
+.post-tile .media {
     width: 100%;
-    height: 100%;
+    display: block;
     object-fit: cover;
-    transition: transform 0.4s ease;
 }
 
-.post-tile:hover img {
-    transform: scale(1.05);
-}
-
-.tile-title-bar {
-    display: none;
-}
-
-.tile-title {
-    font-size: 1.25rem;
-    font-weight: 700;
-    margin: 0;
-}
-
+/* Overlay content */
 .tile-overlay {
     position: absolute;
     inset: 0;
@@ -56,6 +55,12 @@
     background: linear-gradient(to top, rgba(0, 0, 0, 0.85), rgba(0, 0, 0, 0.2));
 }
 
+.tile-title {
+    font-size: 1.25rem;
+    font-weight: 700;
+    margin: 0;
+}
+
 .tile-category {
     font-size: 0.75rem;
     text-transform: uppercase;
@@ -64,26 +69,20 @@
     margin-top: 0.5rem;
 }
 
-.tile-views {
-    font-size: 0.75rem;
-    margin-top: 0.25rem;
-    color: rgba(255, 255, 255, 0.8);
-}
-
 .tile-meta {
     font-size: 0.75rem;
     margin-top: 0.25rem;
     color: rgba(255, 255, 255, 0.8);
 }
 
-.tile-small {
-    grid-row: span 1;
+/* Utility: force width spans with classes (optional) */
+.w-1 { --col-span: 1 }
+.w-2 { --col-span: 2 }
+.w-3 { --col-span: 3 }
+
+@media (max-width: 640px) {
+    :root {
+        --minCol: 180px;
+    }
 }
 
-.tile-medium {
-    grid-row: span 2;
-}
-
-.tile-large {
-    grid-row: span 3;
-}

--- a/app/static/js/loadPosts.js
+++ b/app/static/js/loadPosts.js
@@ -41,14 +41,14 @@
             const category = parts[4] || '';
             const link = document.createElement('a');
             link.href = `/post/${id}`;
-            const sizes = ['tile-small', 'tile-medium', 'tile-large'];
-            link.className = `post-tile ${sizes[Math.floor(Math.random() * sizes.length)]}`;
+            link.className = 'post-tile';
             link.dataset.postId = id;
+            link.dataset.w = Math.floor(Math.random() * 3) + 1;
             const img = document.createElement('img');
             img.dataset.magnetId = `${id}.png`;
             img.src = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
             img.alt = title;
-            img.className = 'select-none';
+            img.className = 'media select-none';
             link.appendChild(img);
 
             const overlay = document.createElement('div');
@@ -65,6 +65,9 @@
             container.appendChild(link);
             if (typeof window.applyPostStats === 'function') {
                 window.applyPostStats(link, id);
+            }
+            if (typeof window.applyMasonry === 'function') {
+                window.applyMasonry(link);
             }
             debug('Added post tile', id);
         }

--- a/app/static/js/postTilesLayout.js
+++ b/app/static/js/postTilesLayout.js
@@ -1,0 +1,50 @@
+(() => {
+    const grid = document.querySelector('.post-tiles-grid');
+    if (!grid) return;
+
+    const gap = () => parseFloat(getComputedStyle(grid).gap) || 0;
+    const autoRow = () => parseFloat(getComputedStyle(grid).gridAutoRows);
+
+    function setColSpan(el) {
+        const w = Math.max(1, Math.min(3, parseInt(el.dataset.w || '1', 10)));
+        el.style.setProperty('--col-span', w);
+    }
+
+    function setRowSpan(el) {
+        const media = el.querySelector('.media');
+        let total = 0;
+        if (media) total += media.getBoundingClientRect().height;
+        const span = Math.max(1, Math.ceil((total + gap()) / (autoRow() + gap())));
+        el.style.setProperty('--row-span', span);
+    }
+
+    function apply(el) {
+        setColSpan(el);
+        setRowSpan(el);
+        const img = el.querySelector('.media');
+        if (img && !img.dataset.masonryBound) {
+            img.dataset.masonryBound = 'true';
+            if (img.complete) {
+                setRowSpan(el);
+            } else {
+                img.addEventListener('load', () => setRowSpan(el), { once: true });
+                img.addEventListener('error', () => setRowSpan(el), { once: true });
+            }
+        }
+    }
+
+    function applyAll() {
+        grid.querySelectorAll('.post-tile').forEach(apply);
+    }
+
+    let resizeTimer;
+    window.addEventListener('resize', () => {
+        clearTimeout(resizeTimer);
+        resizeTimer = setTimeout(applyAll, 100);
+    });
+
+    document.addEventListener('DOMContentLoaded', applyAll);
+
+    window.applyMasonry = apply;
+})();
+

--- a/app/templates/components/postCardMacro.html
+++ b/app/templates/components/postCardMacro.html
@@ -1,15 +1,16 @@
 {% macro postCard(post, authorProfilePicture) %}
-{% set size_class = ['tile-small','tile-medium','tile-large']|random %}
+{% set w = [1,2,3]|random %}
 <a
     href="{{ url_for('post.post', slug=getSlugFromPostTitle(post[1]), urlID=post[10]) }}"
-    class="post-tile {{ size_class }}"
+    class="post-tile"
     data-post-id="{{ post[0] }}"
+    data-w="{{ w }}"
 >
     <img
         data-magnet-id="{{ post[0] }}.png"
         src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw=="
         alt="{{ post[1] }}"
-        class="select-none"
+        class="media select-none"
     />
     <div class="tile-overlay">
         <h2 class="tile-title">{{ post[1] }}</h2>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -55,6 +55,7 @@
 {% endblock body %}
 
 {% block scripts %}
+<script src="{{ url_for('static', filename='js/postTilesLayout.js') }}"></script>
 <script src="{{ url_for('static', filename='js/loadPosts.js') }}"></script>
 <script src="{{ url_for('static', filename='js/postStats.js') }}"></script>
 {% endblock scripts %}

--- a/app/templates/search.html
+++ b/app/templates/search.html
@@ -51,3 +51,8 @@
     {% endif %}
 </div>
 {% endblock body %}
+
+{% block scripts %}
+<script src="{{ url_for('static', filename='js/postTilesLayout.js') }}"></script>
+<script src="{{ url_for('static', filename='js/postStats.js') }}"></script>
+{% endblock scripts %}

--- a/app/templates/user.html
+++ b/app/templates/user.html
@@ -138,3 +138,8 @@
     {% endfor %} {% endif %}
 </div>
 {% endblock body %}
+
+{% block scripts %}
+<script src="{{ url_for('static', filename='js/postTilesLayout.js') }}"></script>
+<script src="{{ url_for('static', filename='js/postStats.js') }}"></script>
+{% endblock scripts %}


### PR DESCRIPTION
## Summary
- replace fixed row tile grid with responsive masonry layout using CSS grid
- compute tile spans dynamically and watch image loading for accurate heights
- preserve post statistics and apply layout across index, search, and user pages

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68afd9097c748327af913e8b9449fccc