### PR TITLE
Support author bios and abstracts in posts

### DIFF
--- a/app/routes/post.py
+++ b/app/routes/post.py
@@ -42,22 +42,22 @@ def post(urlID: int, slug: str | None = None):
     if not onchain:
         return render_template("notFound.html")
 
-    # onchain tuple: (author, contentHash, magnetURI, exists, blacklisted)
+    # onchain tuple: (author, contentHash, magnetURI, authorInfo, exists, blacklisted)
     content_hash = onchain[1]
     parts = content_hash.split("|", 5)
     title = parts[0] if len(parts) > 0 else ""
     tags = parts[1] if len(parts) > 1 else ""
-    author = parts[2] if len(parts) > 2 else onchain[0]
+    abstract = parts[2] if len(parts) > 2 else ""
     content = parts[3] if len(parts) > 3 else ""
     category = parts[4] if len(parts) > 4 else ""
+    author = onchain[0]
+    author_info = onchain[3]
 
     postSlug = getSlugFromPostTitle(title) if title else slug
     if title and slug != postSlug:
         return redirect(url_for("post.post", urlID=urlID, slug=postSlug))
 
-    # simple abstract and reading time calculations
     clean_text = sub(r"<[^>]+>", "", content)
-    abstract = clean_text[:150]
     reading_time = max(1, ceil(len(clean_text.split()) / 200))
 
     return render_template(
@@ -85,6 +85,7 @@ def post(urlID: int, slug: str | None = None):
         comment_contract_abi=Settings.BLOCKCHAIN_CONTRACTS["CommentStorage"]["abi"],
         content=content,
         reading_time=reading_time,
+        author_info=author_info,
     )
 
 

--- a/app/settings.py
+++ b/app/settings.py
@@ -455,6 +455,25 @@ class Settings:
       "type": "event"
     },
     {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "postId",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "authorInfo",
+          "type": "string"
+        }
+      ],
+      "name": "AuthorInfoUpdated",
+      "type": "event"
+    },
+    {
       "inputs": [
         {
           "internalType": "string",
@@ -483,6 +502,11 @@ class Settings:
         {
           "internalType": "string",
           "name": "magnetURI",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "authorInfo",
           "type": "string"
         }
       ],
@@ -581,6 +605,11 @@ class Settings:
               "type": "string"
             },
             {
+              "internalType": "string",
+              "name": "authorInfo",
+              "type": "string"
+            },
+            {
               "internalType": "bool",
               "name": "exists",
               "type": "bool"
@@ -657,6 +686,11 @@ class Settings:
           "type": "string"
         },
         {
+          "internalType": "string",
+          "name": "authorInfo",
+          "type": "string"
+        },
+        {
           "internalType": "bool",
           "name": "exists",
           "type": "bool"
@@ -702,6 +736,24 @@ class Settings:
         }
       ],
       "name": "setImageBlacklist",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "postId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "string",
+          "name": "authorInfo",
+          "type": "string"
+        }
+      ],
+      "name": "updateAuthorInfo",
       "outputs": [],
       "stateMutability": "nonpayable",
       "type": "function"

--- a/app/static/js/createPost.js
+++ b/app/static/js/createPost.js
@@ -32,14 +32,15 @@
             const title = form.postTitle.value.trim();
             const tags = form.postTags.value.trim();
             const abs = form.postAbstract.value.trim();
+            const info = form.authorInfo ? form.authorInfo.value.trim() : '';
             const content = form.postContent.value.trim();
             const category = form.postCategory.value;
             const magnet = magnetField ? magnetField.value.trim() : '';
-            const payload = `${title}|${tags}|${abs}|${content}|${category}|${magnet}`;
+            const payload = `${title}|${tags}|${abs}|${content}|${category}`;
             const provider = new ethers.providers.Web3Provider(window.ethereum);
             const signer = provider.getSigner();
             const contract = new ethers.Contract(postContractAddress, postContractAbi, signer);
-            const tx = await contract.createPost(payload, magnet);
+            const tx = await contract.createPost(payload, magnet, info);
             debug('Transaction sent', tx.hash);
             const receipt = await tx.wait();
             debug('Transaction mined', receipt.transactionHash);

--- a/app/static/js/postContent.js
+++ b/app/static/js/postContent.js
@@ -25,11 +25,17 @@
     try {
         const p = await contract.getPost(postUrlID);
         debug('Fetched post', p);
-        const content = p.contentHash;
+        const parts = p.contentHash.split('|');
+        const content = parts[3] || '';
+        const abstract = parts[2] || '';
         const contentEl = document.getElementById('post-content');
         if (contentEl) {
             contentEl.innerHTML = marked.parse(content);
             debug('Rendered content');
+        }
+        const abstractEl = document.querySelector('.text-center.font-sm.max-w-full');
+        if (abstractEl) {
+            abstractEl.textContent = abstract;
         }
         const cleanText = content.replace(/<[^>]+>/g, '');
         const words = cleanText.trim().split(/\s+/).filter(Boolean).length;

--- a/app/templates/createPost.html
+++ b/app/templates/createPost.html
@@ -16,6 +16,7 @@
         form.postAbstract(class_="textarea textarea-bordered w-full my-2",
         autocomplete="off",placeholder=translations.createPost.abstractPlaceholder)
         }}
+        {{ form.authorInfo(class_="textarea textarea-bordered w-full my-2", autocomplete="off", placeholder="About the author") }}
         <p class="text-xs text-center w-fit mx-auto mb-2">
             {{ translations.createPost.separate }}
         </p>

--- a/app/templates/post.html
+++ b/app/templates/post.html
@@ -35,12 +35,10 @@
             </div>
         </div>
         <div class="flex w-full justify-between my-1">
-            <a href="/user/{{ author | lower }}" class="hover:text-rose-500 duration-150">
-                <h5 class="m-1 flex">
-                    <img class="w-7 mr-2 select-none" src="{{ getProfilePicture(author) }}" alt="{{ author }}" />
-                    {{ author }}
-                </h5>
-            </a>
+            <h5 class="m-1 flex">
+                <img class="w-7 mr-2 select-none" src="{{ getProfilePicture(author) }}" alt="{{ author }}" />
+                {{ author_info }}
+            </h5>
         </div>
     </div>
 </div>

--- a/app/utils/forms/CreatePostForm.py
+++ b/app/utils/forms/CreatePostForm.py
@@ -32,6 +32,11 @@ class CreatePostForm(Form):
         [validators.Length(min=150, max=200), validators.InputRequired()],
     )
 
+    authorInfo = TextAreaField(
+        "Author Info",
+        [validators.Optional(), validators.Length(max=200)],
+    )
+
     postContent = TextAreaField(
         "Post Content",
         [validators.Length(min=50)],


### PR DESCRIPTION
## Summary
- allow posts to include updatable author info in PostStorage contract
- show provided abstract and author details on post pages
- extend create-post form, JS, and ABI to handle author info

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68afe33889b88327ae9e2806002d33c7